### PR TITLE
HOMEとAWAYで背景色を変更した

### DIFF
--- a/app/javascript/components/list/MatchResultList.vue
+++ b/app/javascript/components/list/MatchResultList.vue
@@ -8,7 +8,15 @@
           <p>{{ result.competition_name }}</p>
         </div>
         <div class="team">
-          <p class="home_and_away" v-bind:class="(data.isHome === result.home_and_away ? 'has-background-success' : 'has-background-danger' )">{{ result.home_and_away }}</p>
+          <p
+            class="home_and_away"
+            v-bind:class="
+              data.isHome === result.home_and_away
+                ? 'has-background-success'
+                : 'has-background-danger'
+            ">
+            {{ result.home_and_away }}
+          </p>
           <p class="team_name_and_logo">{{ result.home_team_name }}</p>
           <img :src="result.home_logo" class="image is-96x96" />
           <p class="team_name_and_logo">{{ result.home_score }}</p>

--- a/app/javascript/components/list/MatchScheduleList.vue
+++ b/app/javascript/components/list/MatchScheduleList.vue
@@ -11,7 +11,15 @@
           <p>{{ schedule.competition_name }}</p>
         </div>
         <div class="team">
-          <p class="home_and_away" v-bind:class="(data.isHome === schedule.home_and_away ? 'has-background-success' : 'has-background-danger' )">{{ schedule.home_and_away }}</p>
+          <p
+            class="home_and_away"
+            v-bind:class="
+              data.isHome === schedule.home_and_away
+                ? 'has-background-success'
+                : 'has-background-danger'
+            ">
+            {{ schedule.home_and_away }}
+          </p>
           <p class="team_name_and_logo">{{ schedule.home_team_name }}</p>
           <img :src="schedule.home_logo" class="image is-96x96" />
           <p class="team_name_and_logo">-</p>
@@ -28,7 +36,7 @@ import { reactive } from 'vue'
 
 export default {
   props: ['matchScheduleFilter'],
-    setup() {
+  setup() {
     const data = reactive({
       isHome: 'HOME'
     })
@@ -37,7 +45,6 @@ export default {
       data
     }
   }
-
 }
 </script>
 <style>

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -2,17 +2,41 @@
   <div class="has-text-centered">
     <div class="container">
       <ul v-for="league in data.leagues" :key="league.id">
-        <li class="mt-5 mx-6 p-2" @click="selectLeague(league)" v-bind:class="{ 'has-background-link-light' : data.isChangeColorLeague === league.id}">
+        <li
+          class="mt-5 mx-6 p-2"
+          @click="selectLeague(league)"
+          v-bind:class="{
+            'has-background-link-light': data.isChangeColorLeague === league.id
+          }">
           <img :src="league.logo" class="image is-128x128" />
-          <p class="has-text-weight-semibold"  v-bind:class="{ 'has-text-weight-bold has-text-danger' : data.isChangeColorLeague === league.id}">{{ league.name }}</p>
+          <p
+            class="has-text-weight-semibold"
+            v-bind:class="{
+              'has-text-weight-bold has-text-danger':
+                data.isChangeColorLeague === league.id
+            }">
+            {{ league.name }}
+          </p>
         </li>
       </ul>
     </div>
     <div class="container">
       <ul v-for="team in teamFilter" :key="team.id">
-        <li class="mt-5 mx-6 p-2" @click="selectTeam(team)" v-bind:class="{ 'has-background-link-light' : data.isChangeColorTeam === team.id}">
+        <li
+          class="mt-5 mx-6 p-2"
+          @click="selectTeam(team)"
+          v-bind:class="{
+            'has-background-link-light': data.isChangeColorTeam === team.id
+          }">
           <img :src="team.logo" class="image is-128x128" />
-          <p class="has-text-weight-semibold" v-bind:class="{ 'has-text-weight-bold has-text-danger' : data.isChangeColorTeam === team.id}">{{ team.name }}</p>
+          <p
+            class="has-text-weight-semibold"
+            v-bind:class="{
+              'has-text-weight-bold has-text-danger':
+                data.isChangeColorTeam === team.id
+            }">
+            {{ team.name }}
+          </p>
         </li>
       </ul>
     </div>
@@ -63,7 +87,9 @@ export default {
 
     const selectLeague = (league) => {
       store.commit('addLeague', league.id)
-      data.isChangeColorLeague === league.id ? data.isChangeColorLeague = '' : data.isChangeColorLeague = league.id
+      data.isChangeColorLeague === league.id
+        ? (data.isChangeColorLeague = '')
+        : (data.isChangeColorLeague = league.id)
     }
 
     const teamFilter = computed(() => {
@@ -76,7 +102,9 @@ export default {
     const selectTeam = (team) => {
       store.commit('increment', team.id)
       data.isShowing = true
-      data.isChangeColorTeam === team.id ? data.isChangeColorTeam = '' : data.isChangeColorTeam = team.id
+      data.isChangeColorTeam === team.id
+        ? (data.isChangeColorTeam = '')
+        : (data.isChangeColorTeam = team.id)
     }
 
     onMounted(setLeague(), setTeam())

--- a/app/javascript/components/table/FavoriteTeamTable.vue
+++ b/app/javascript/components/table/FavoriteTeamTable.vue
@@ -9,7 +9,15 @@
         <div class="match_schedules">
           <div>
             <img :src="match.competition_logo" class="image is-24x24" />
-            <p class="has-text-white" v-bind:class="(data.isHome === match.home_and_away ? 'has-background-success' : 'has-background-danger')">{{ match.home_and_away }}</p>
+            <p
+              class="has-text-white"
+              v-bind:class="
+                data.isHome === match.home_and_away
+                  ? 'has-background-success'
+                  : 'has-background-danger'
+              ">
+              {{ match.home_and_away }}
+            </p>
           </div>
           <div>
             <p>{{ match.date }}</p>
@@ -36,7 +44,6 @@ export default {
     const data = reactive({
       isHome: 'HOME'
     })
-
 
     const selectTeam = (standings) => {
       store.commit('addShedulesParams', standings.team_id)


### PR DESCRIPTION
## 対応した issue
#92 
## 対応内容・対応背景・妥協点
HOMEとAWAYは試合結果に大きな影響を与える。これまでもHOMEとAWAYは表示されていたが、色分けされていなかったため、直感的に理解しにくい仕様だった。
## やったこと
- 日程表と試合結果・試合予定で表示されるHOMEとAWAYの背景色を変更した
## やってないこと
- CSSをBulmaで書き換える
## UI before / after
### 日程表
#### before
<img width="938" alt="Football" src="https://user-images.githubusercontent.com/62058863/166696911-6a77bed0-435e-4bec-8ee4-a4a5fd23d177.png">

#### after
<img width="1712" alt="Football_🔊" src="https://user-images.githubusercontent.com/62058863/166696739-1d10d751-7973-4549-9a9a-9f3198f3483b.png">

### 試合結果
#### before
<img width="1224" alt="Football" src="https://user-images.githubusercontent.com/62058863/166696819-51a6a000-18fd-4155-9e56-988bc2bd9912.png">

#### after
<img width="1139" alt="Football_🔊" src="https://user-images.githubusercontent.com/62058863/166696666-8f22ff77-8827-4935-bbd6-d058df4f2f3a.png">
### 試合予定

#### before
<img width="897" alt="Football_🔊" src="https://user-images.githubusercontent.com/62058863/166696785-ee4c1068-8551-45f0-a60f-e3abac6df951.png">

#### after
<img width="1709" alt="Football_🔊" src="https://user-images.githubusercontent.com/62058863/166696590-3e63af33-55d3-430d-9728-8ef663aa8a3d.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
