### PR TITLE
アカウント登録できるemailを制限した

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -184,7 +184,7 @@ Devise.setup do |config|
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
   # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
-  config.email_regexp = /fjord2022+@example.com/
+  config.email_regexp = /fjord\d+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
## 対応した issue
#144 
## 対応内容・対応背景・妥協点
- レビュー用に登録できるアカウントを制限した
- #148 でアカウント作成の制限をしたが一つのメールアドレスでしか登録できなかったため修正した
