### PR TITLE
304エラーが出ないようにメソッドを追加した

### DIFF
--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -71,8 +71,18 @@ class Api::MatchesController < ApplicationController
 
   def api_request_url
     api_id = competitor_teams.unshift(favorite_team_api_id)
-    api_id.map { |i| URI("https://v3.football.api-sports.io/fixtures?&season=2021&team=#{i}&from=2022-03-30&to=2022-05-30") }
+    api_id.map { |i| URI("https://v3.football.api-sports.io/fixtures?&season=2021&team=#{i}&from=2022-#{prev_date}&to=2022-#{next_date}") }
   end
+
+  # レビュー用に日付を調節
+  def prev_date
+    '03-30'
+  end
+
+  def next_date
+    '04-30'
+  end
+  # ここまで
 
   def competitor_teams
     competitor_team_id = current_user.competitor.map(&:team_id)


### PR DESCRIPTION


## 対応した issue
#160 
## 対応内容・対応背景・妥協点
直接日程を入力しているとキャッシュで処理されてしまうため304が返ってきてしまい、データーを取得できなかった

