### PR TITLE
リーグ一覧のレイアウトを修正する&CSSの二重読み込みを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,8 @@ footer {
 .league-logo {
   width: 4rem;
   max-width: 100%;
+  height: 4rem;
+  max-height: 100%;
 }
 
 .team-logo {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,7 +96,8 @@ footer {
   }
 }
 
-.team-select-description {
+.box.team-select-description {
+  background-color: #d1d1e9;
   @include tablet {
     width: 40rem;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,6 +96,15 @@ footer {
   }
 }
 
+.team-select-description {
+  @include tablet {
+    width: 40rem;
+  }
+  @include mobile {
+    width: 18rem;
+  }
+}
+
 /* 文字列の折り返し */
 .is-break-all {
   word-break: break-all;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,19 +1,4 @@
 @import "bulma";
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
 
 /* layout */
 $main: #6246ea;

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -4,22 +4,29 @@
       class="has-text-centered is-size-2-tablet is-size-4-mobile has-text-weight-bold">
       応援しているチームを選んでください
     </h2>
-      <div class="box team-select-description mt-3 mx-auto" v-if="!data.competitors.length">
-        <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">チーム選びの手順</p>
-        <ol class="p-2 is-size-6-mobile">
-          <li class="p-1">あなたが応援しているチームを選びます。</li>
-          <li class="p-1">1で選んだのと同じリーグの中からライバルチームを選びます。</li>
-          <li class="p-1">まずは応援しているチームが所属しているリーグを選んでください。</li>
-        </ol>
-      </div>
-      <div
-        class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
-        v-else
-      >
-        <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
-      </div>
-      <LeagueListLoader v-if="!data.leagues.length" />
-      <div v-else>
+    <div
+      class="box team-select-description mt-3 mx-auto"
+      v-if="!data.competitors.length">
+      <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">
+        チーム選びの手順
+      </p>
+      <ol class="p-2 is-size-6-mobile">
+        <li class="p-1">あなたが応援しているチームを選びます。</li>
+        <li class="p-1">
+          1で選んだのと同じリーグの中からライバルチームを選びます。
+        </li>
+        <li class="p-1">
+          まずは応援しているチームが所属しているリーグを選んでください。
+        </li>
+      </ol>
+    </div>
+    <div
+      class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
+      v-else>
+      <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
+    </div>
+    <LeagueListLoader v-if="!data.leagues.length" />
+    <div v-else>
       <h3 class="has-text-centered is-size-3 my-4 has-text-weight-bold">
         リーグ一覧
       </h3>

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -2,23 +2,23 @@
   <div class="container">
     <h2
       class="has-text-centered is-size-2-tablet is-size-4-mobile has-text-weight-bold">
-      登録したい応援しているチームを選んでください
+      応援しているチームを選んでください
     </h2>
-    <div
-      class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
-      v-if="data.isChangeColorLeague">
-      <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
-    </div>
-    <div v-else>
-      <p class="is-size-4 has-text-centered has-text-weight-bold mt-5">
-        あなたが応援しているチームを選びます。そのあとに同じリーグの中からライバルチームを選びます。
-      </p>
-      <p class="is-size-4 has-text-centered has-text-weight-bold my-5">
-        まずは応援しているチームが所属しているチームを選んでください
-      </p>
-    </div>
-    <LeagueListLoader v-if="!data.leagues.length" />
-    <div v-else>
+      <div
+        class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
+        v-if="data.isChangeColorLeague">
+        <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
+      </div>
+      <div class="team-select-description box mt-3 mx-auto" v-else>
+        <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">チーム選びの手順</p>
+        <ol class="p-2 is-size-6-mobile">
+          <li class="p-1">あなたが応援しているチームを選びます。</li>
+          <li class="p-1">1で選んだのと同じリーグの中からライバルチームを選びます。</li>
+          <li class="p-1">まずは応援しているチームが所属しているリーグを選んでください。</li>
+        </ol>
+      </div>
+      <LeagueListLoader v-if="!data.leagues.length" />
+      <div v-else>
       <h3 class="has-text-centered is-size-3 my-4 has-text-weight-bold">
         リーグ一覧
       </h3>
@@ -39,7 +39,7 @@
               alt="league_name"
               class="image mx-auto league-logo" />
             <p
-              class="has-text-weight-semibold mt-2 is-size-6-tablet is-size-7-mobile is-break-all"
+              class="has-text-weight-semibold mt-2 is-size-5-tablet is-size-7-mobile is-break-all"
               v-bind:class="{
                 'has-text-weight-bold': data.isChangeColorLeague === league.id
               }">

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -4,18 +4,19 @@
       class="has-text-centered is-size-2-tablet is-size-4-mobile has-text-weight-bold">
       応援しているチームを選んでください
     </h2>
-      <div
-        class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
-        v-if="data.isChangeColorLeague">
-        <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
-      </div>
-      <div class="team-select-description box mt-3 mx-auto" v-else>
+      <div class="box team-select-description mt-3 mx-auto" v-if="!data.competitors.length">
         <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">チーム選びの手順</p>
         <ol class="p-2 is-size-6-mobile">
           <li class="p-1">あなたが応援しているチームを選びます。</li>
           <li class="p-1">1で選んだのと同じリーグの中からライバルチームを選びます。</li>
           <li class="p-1">まずは応援しているチームが所属しているリーグを選んでください。</li>
         </ol>
+      </div>
+      <div
+        class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
+        v-else
+      >
+        <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
       </div>
       <LeagueListLoader v-if="!data.leagues.length" />
       <div v-else>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,6 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs'
-import '../../assets/stylesheets/application.scss'
 import 'main.js'
 import * as ActiveStorage from '@rails/activestorage'
 import 'channels'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ League.create(
     {
       "id": 1,
       "api_id": 39,
-      "name": 'Premier League',
+      "name": 'Premier',
       "logo": 'https://media.api-sports.io/football/leagues/39.png'
     },
     {
@@ -23,7 +23,7 @@ League.create(
     {
       "id": 4,
       "api_id": 78,
-      "name": 'Bundesliga 1',
+      "name": 'Bundes',
       "logo": 'https://media.api-sports.io/football/leagues/78.png'
     }
   ]


### PR DESCRIPTION
## 対応した issue
#167 
#149 
## 対応内容・対応背景・妥協点
- 画像サイズと文字数の問題でモバイルサイズのときにレイアウトが崩れていた
- チームを登録する手順を見やすくするためにボックスを追加した
- CSSが二重で読み込まれている問題を修正
## やったこと
- 画像サイズを設定
- 初期データを変更
- チーム登録手順のレイアウトを変更
- jsでcssを読み込まないようにした
## やってないこと
- チーム一覧のレイアウト
## UI before / after
### before
<img width="763" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172790273-d9c20d9a-c76c-4de0-a1b3-07f72c72dfb9.png">

<img width="279" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172811805-7f7f52fe-276a-4de4-bd7d-4b9981f98c52.png">

### after
<img width="369" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172811853-13378e45-244d-4025-8ad2-3f2491be3dc2.png">

<img width="362" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172811895-dff7c260-1be0-4e6b-b0af-56c61af76691.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
