### PR TITLE
ライバルチーム選択時のレイアウトを修正

### DIFF
--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -68,7 +68,7 @@
       </h3>
       <div class="columns is-mobile">
         <div
-          class="column is-one-third"
+          class="column is-one-third mx-auto"
           v-for="team in data.selectedTeams.slice(0, 3)"
           :key="team.id">
           <div class="card">

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -160,7 +160,6 @@
 <script>
 import axios from 'axios'
 import { reactive, onMounted } from 'vue'
-import { useStore } from 'vuex'
 import CompetitorValidation from '../../modal/CompetitorValidation.vue'
 import CompetitorTeamCount from '../../modal/CompetitorTeamCount.vue'
 import TeamListLoader from '../../loader/TeamListLoader'
@@ -184,8 +183,6 @@ export default {
       isSelected: false,
       isShowingMessage: true
     })
-
-    const store = useStore()
 
     const setTeam = async () => {
       axios
@@ -273,7 +270,6 @@ export default {
             console.log(error)
           })
       )
-      teamId.map((id) => store.commit('addCompetitor', id))
     }
 
     // 自分でチームを選択する
@@ -301,8 +297,6 @@ export default {
     return {
       data,
       selectCompetitorTeams,
-      addCompetitor: () => store.commit('addCompetitor'),
-      deleteCompetitor: () => store.commit('deleteCompetitor'),
       autoSelect,
       selectTeam,
       again,

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,7 +10,7 @@ html
     = javascript_pack_tag 'application'
     = favicon_link_tag 'favicon.png'
   body
-    header.mb-6
+    header
       .navbar.is-transparent.is-fixed-top.p-2.has-background-main
         .navbar-brand
           .title


### PR DESCRIPTION
## 対応した issue
#171 
## 対応内容・対応背景・妥協点
- ライバルチームを選択するときに3チーム選ばなかったときにレイアウトが左寄りになっていた
## やったこと
- カードが中央に寄るように設定した

## やってないこと
- 文字数が多いことによるレイアウトの崩れは修正していない。都市名の文字数を減らそうとしたが、どこで区切っていいかわからなかった

## UI before / after
### before
<img width="332" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172853645-1d203dee-a028-45d0-b6e4-06b72ac6453d.png">

<img width="280" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172853690-9390245c-ce3a-42e6-a36a-b9e42047fb77.png">

### after
<img width="364" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172854249-da4f65e3-865c-4733-abad-ef0add929749.png">

<img width="354" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172854276-9d0ba6e6-dc0f-4438-9d6a-7ddfec7d7a92.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
