### PR TITLE
ライバルチームを変更するときに前回の登録が残るエラーを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,6 +96,11 @@ footer {
   word-break: break-all;
 }
 
+input.how-to-team-select:hover {
+  cursor: pointer;
+  opacity: 0.6;
+}
+
 .box.how-to-competitor-team-select {
   background-color: #d1d1e9;
   width: 80rem;

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -114,7 +114,7 @@
       </button>
       <button
         class="button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
-        @click="again">
+        @click="selectAgain">
         チームの選び方を変更する
       </button>
     </div>
@@ -162,7 +162,7 @@
       </button>
       <button
         class="button is-rounded is-medium mt-4 ml-2 is-size-4-tablet is-size-7-mobile"
-        @click="again">
+        @click="selectAgain">
         チームの選択方法を選び直す
       </button>
     </div>
@@ -267,7 +267,7 @@ export default {
       data.isSelected = false
     }
 
-    const again = () => {
+    const selectAgain = () => {
       data.isShowing = true
       data.isAdding = false
       data.isFreeSelect = false
@@ -300,7 +300,7 @@ export default {
       selectCompetitorTeams,
       autoSelect,
       selectTeam,
-      again,
+      selectAgain,
       deleteMessage,
       followTeam
     }

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -64,14 +64,21 @@
     <!-- has-text-centered -->
     <div v-show="data.isAdding">
       <h3 class="is-size-2-tablet is-size-5-mobile has-text-weight-bold mb-3">
-        こちらのチームを登録しますか？
+        登録したいチームを選んでください
       </h3>
       <div class="columns is-mobile">
         <div
           class="column is-one-third mx-auto"
           v-for="team in data.selectedTeams.slice(0, 3)"
           :key="team.id">
-          <div class="card">
+          <div
+            class="card has-hover-action select-button"
+            @click="followTeam(team)"
+            v-bind:class="{
+              'has-background-link-light is-selected': data.competitors.some(
+                (competitor) => competitor.team_id === team.id
+              )
+            }">
             <img
               :src="team.logo"
               class="image competitor-team-logo mx-auto pt-1" />
@@ -94,7 +101,7 @@
       <br />
       <button
         class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
-        @click="addCompetitorFollow">
+      >
         <router-link to="/schedules" class="has-text-white"
           >上記のチームを登録する</router-link
         >

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -18,7 +18,7 @@
             for="rank">
             <input
               type="radio"
-              class="rank mb-4"
+              class="how-to-team-select rank mb-4"
               value="rank"
               v-model="data.checkedName" />
             昨シーズンの順位が近いチームを選ぶ</label
@@ -29,7 +29,7 @@
             for="home">
             <input
               type="radio"
-              class="home mb-4"
+              class="how-to-team-select home mb-4"
               value="home"
               v-model="data.checkedName" />
             本拠地が近いチームを選ぶ</label
@@ -40,7 +40,7 @@
             for="self">
             <input
               type="radio"
-              class="self mb-4"
+              class="how-to-team-select self mb-4"
               value="self"
               v-model="data.checkedName" />
             自分でライバルチームを選ぶ</label
@@ -307,10 +307,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-input:hover {
-  cursor: pointer;
-  opacity: 0.6;
-}
-</style>

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="container has-text-centered">
+    <!-- ライバルチーム選択方法を選んでもらう -->
     <div class="notification is-danger is-size-4" v-show="data.isSelected">
       <button class="delete" @click="deleteMessage"></button>
       ライバルチームの選択方法を一つ選んでください
@@ -62,6 +63,7 @@
       </button>
     </div>
     <!-- has-text-centered -->
+    <!--ライバルチームの選択方法を選んでもらったあと-->
     <div v-show="data.isAdding">
       <CompetitorTeamCount
         :competitors="data.competitors"
@@ -72,8 +74,8 @@
       </h3>
       <div class="columns is-mobile">
         <div
-          class="column is-one-third mx-auto"
-          v-for="team in data.selectedTeams.slice(0, 3)"
+          class="column mx-auto"
+          v-for="team in data.selectedTeams"
           :key="team.id">
           <div
             class="card has-hover-action select-button"
@@ -107,7 +109,7 @@
         class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
       >
         <router-link to="/schedules" class="has-text-white"
-          >上記のチームを登録する</router-link
+          >選んだチームを登録する</router-link
         >
       </button>
       <button
@@ -116,6 +118,7 @@
         チームの選び方を変更する
       </button>
     </div>
+    <!--自分でチーム選んでもらう -->
     <!-- v-show -->
     <div v-show="data.isFreeSelect">
       <CompetitorTeamCount
@@ -229,6 +232,10 @@ export default {
     }
 
     // 自動登録の処理
+    const selectTeam = () => {
+      autoSelect()
+    }
+
     const autoSelect = () => {
       if (data.checkedName === 'home') {
         data.selectedTeams = data.teams.filter(
@@ -266,23 +273,6 @@ export default {
       data.isFreeSelect = false
     }
 
-    const selectTeam = () => {
-      autoSelect()
-    }
-
-    const addCompetitorFollow = () => {
-      const teamId = data.selectedTeams.slice(0, 3).map((team) => team.id)
-      teamId.forEach((id) =>
-        axios
-          .post('/api/competitors', {
-            id: id
-          })
-          .catch(function (error) {
-            console.log(error)
-          })
-      )
-    }
-
     // 自分でチームを選択する
     const followTeam = (team) => {
       selectCompetitorTeams(team.id)
@@ -311,7 +301,6 @@ export default {
       autoSelect,
       selectTeam,
       again,
-      addCompetitorFollow,
       deleteMessage,
       followTeam
     }

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -107,8 +107,7 @@
       <br />
       <button
         v-if="data.competitors.length <= 3"
-        class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
-      >
+        class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile">
         <router-link to="/schedules" class="has-text-white"
           >選んだチームを登録する</router-link
         >
@@ -116,8 +115,8 @@
       <button
         v-else
         class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
-        title="Disabled button" disabled
-      >
+        title="Disabled button"
+        disabled>
         選んだチームを登録する
       </button>
       <button
@@ -171,8 +170,8 @@
       <button
         v-else
         class="color-button button is-rounded is-medium mt-4 ml-2 is-size-4-tablet is-size-7-mobile"
-        title="Disabled button" disabled
-      >
+        title="Disabled button"
+        disabled>
         選んだチームを登録する
       </button>
       <button

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -106,11 +106,19 @@
       <!-- columns -->
       <br />
       <button
+        v-if="data.competitors.length <= 3"
         class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
       >
         <router-link to="/schedules" class="has-text-white"
           >選んだチームを登録する</router-link
         >
+      </button>
+      <button
+        v-else
+        class="color-button button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
+        title="Disabled button" disabled
+      >
+        選んだチームを登録する
       </button>
       <button
         class="button is-rounded is-medium mt-2 ml-2 is-size-4-tablet is-size-7-mobile"
@@ -155,10 +163,17 @@
       <!-- v-else -->
       <button
         class="color-button button is-rounded is-medium mt-4 ml-2 is-size-4-tablet is-size-7-mobile"
-        v-if="data.competitors.length >= 1">
+        v-if="data.competitors.length >= 1 && data.competitors.length <= 3">
         <router-link to="/schedules" class="has-text-white"
-          >ライバルチームを決定する</router-link
+          >選んだチームを登録する</router-link
         >
+      </button>
+      <button
+        v-else
+        class="color-button button is-rounded is-medium mt-4 ml-2 is-size-4-tablet is-size-7-mobile"
+        title="Disabled button" disabled
+      >
+        選んだチームを登録する
       </button>
       <button
         class="button is-rounded is-medium mt-4 ml-2 is-size-4-tablet is-size-7-mobile"

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -63,6 +63,10 @@
     </div>
     <!-- has-text-centered -->
     <div v-show="data.isAdding">
+      <CompetitorTeamCount
+        :competitors="data.competitors"
+        v-if="data.isShowingMessage" />
+      <CompetitorValidation v-else />
       <h3 class="is-size-2-tablet is-size-5-mobile has-text-weight-bold mb-3">
         登録したいチームを選んでください
       </h3>

--- a/spec/system/competitor_team_select_spec.rb
+++ b/spec/system/competitor_team_select_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe 'ライバルチームを登録する', type: :system, js: true d
     click_button 'チームの選択方法を決定する'
     expect(page).to have_content 'Manchester United'
     expect(page).to_not have_content 'Tottenham'
-    expect(page).to have_content '上記のチームを登録する'
+    all('img')[1].click
+    expect(page).to have_content '残り2チーム登録できます'
+    expect(page).to have_content '選んだチームを登録する'
   end
 
   it '本拠地が近いチームを選ぶ', js: true do
@@ -31,7 +33,9 @@ RSpec.describe 'ライバルチームを登録する', type: :system, js: true d
     click_button 'チームの選択方法を決定する'
     expect(page).to have_content 'Tottenham'
     expect(page).to_not have_content 'Manchester United'
-    expect(page).to have_content '上記のチームを登録する'
+    all('img')[1].click
+    expect(page).to have_content '残り2チーム登録できます'
+    expect(page).to have_content '選んだチームを登録する'
   end
 
   it '自分でライバルチームを選ぶ', js: true do
@@ -43,7 +47,7 @@ RSpec.describe 'ライバルチームを登録する', type: :system, js: true d
     sleep 2.0
     all('img')[1].click
     expect(page).to have_content '残り2チーム登録できます'
-    expect(page).to have_content 'ライバルチームを決定する'
+    expect(page).to have_content '選んだチームを登録する'
   end
 
   it 'チームの選択方法を選ばなかった時のメッセージを表示', js: true do


### PR DESCRIPTION
## 対応した issue
#174 
## 対応内容・対応背景・妥協点
- ライバルチームをを変更するときに「自分でライバルチームを選ぶ」以外を選択すると、チームが正しく変更されなかった
## やったこと
- 「自分でチームを選ぶ」と同じようにチームを登録できるようにした。
- 「自分でチームを選ぶ」以外でも現在の登録数を表示するようにした。
- 3チーム以上ライバルチームを選んだら、次に進むボタンを選択できないようにした。
## やってないこと
- リファクタリング
## UI before / after
### before

1. ホーム画面
<img width="1002" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172968427-ce834cac-ad70-47b7-9d34-e7f713ddca47.png">

2. ライバルチームを変更
<img width="987" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172968465-f14e97c8-3f8d-4cdf-9443-cd3fded0ac8c.png">

3. 変わってない
<img width="1007" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/172968483-e60c8abb-c1e3-4b84-b366-ebde7b0c4642.png">

### after
登録方法を変更した

[![Image from Gyazo](https://i.gyazo.com/31535c65ea2d695613eb0158030e2b7b.gif)](https://gyazo.com/31535c65ea2d695613eb0158030e2b7b)

## テスト

- [ ] `bin/lint`を実行した
- [ ] `bundle exec rspec`を実行した
