### PR TITLE
フッターが表示されるようにCSSを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,7 @@ main {
   background-color: $main;
 }
 
-footer {
+.hero-body {
   background-color: #6246ea;
 }
 


### PR DESCRIPTION
## 対応した issue
#178 
## 対応内容・対応背景・妥協点
フッターが表示されていなかった
## やったこと
CSSを修正してフッターが表示されるようにした
## UI before / after
### before
<img width="1430" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/173336589-dade836b-64e1-4d4b-9a8b-1dbaa892e76e.png">

### after
<img width="1377" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/173336683-37ebc191-9549-40fb-a741-95df494dd4b0.png">

## テスト

- [ ] `bin/lint`を実行した
- [ ] `bundle exec rspec`を実行した
