### PR TITLE
試合日程の固定とアカウント登録制限を解除

### DIFF
--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -25,7 +25,9 @@ class API::MatchesController < ApplicationController
 
   def api_request_url
     api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
-    api_id.map { |i| URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}") }
+    api_id.map do |i|
+      URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}")
+    end
   end
 
   def match_date

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -5,7 +5,7 @@ class API::MatchesController < ApplicationController
   before_action :set_show_page, only: [:show]
 
   def index
-    @match = Match.all.order(:date).first(9)
+    @match = Match.all.order(:date).where(date: Time.zone.today..)
   end
 
   def show
@@ -23,10 +23,9 @@ class API::MatchesController < ApplicationController
     MatchRequest.league(api_request_url)
   end
 
-  # レビュー用に日付を調節
   def api_request_url
     api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
-    api_id.map { |i| URI("https://v3.football.api-sports.io/fixtures?&season=#{current_season}&team=#{i}&from=#{match_date}") }
+    api_id.map { |i| URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}") }
   end
 
   def match_date
@@ -36,7 +35,6 @@ class API::MatchesController < ApplicationController
   def current_season
     '2021'
   end
-  # ここまで
 
   def competitor_teams
     SelectTeam.competitor(current_user)

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -19,7 +19,7 @@ class API::StandingsController < ApplicationController
 
   def api_request_url
     team_numbers = competitor_team_api_id.unshift(favorite_team.api_id)
-    team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id(favorite_team)}&season=2021&team=#{number}") }
+    team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id(favorite_team)}&season=#{Year.season}&team=#{number}") }
   end
 
   def competitor_team_api_id

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -184,7 +184,7 @@ Devise.setup do |config|
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
   # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
-  config.email_regexp = /fjord\d+@[^@\s]+\z/
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
## 対応した issue
#187 
#189 
## 対応内容・対応背景・妥協点
- コードレビュー用に変更していたものを元に戻した
## やったこと
- APIリクエストを現在の日付を元に行うようにした
- アカウント登録できるアドレスの制限を無くした

## やってないこと
- 新しい機能の追加

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
