### PR TITLE
チーム選択の手順の背景色を変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -90,9 +90,9 @@ main {
 }
 
 .box.team-select-description {
-  background-color: #d1d1e9;
+  border: solid 1px;
   @include tablet {
-    width: 40rem;
+    width: 36rem;
   }
   @include mobile {
     width: 18rem;

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -10,7 +10,7 @@
       <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">
         チーム選びの手順
       </p>
-      <ol class="p-2 is-size-6-mobile">
+      <ol class="p-2 is-size-6-mobile has-text-centered">
         <li class="p-1">あなたが応援しているチームを選びます。</li>
         <li class="p-1">
           1で選んだのと同じリーグの中からライバルチームを選びます。


### PR DESCRIPTION
## 対応した issue
#192 
## 対応内容・対応背景・妥協点
チーム選択の手順の背景色を変更した。
ライバルチームの選び方を選択する画面の背景色を変更したため、それに併せて変更した

## UI before / after
### before
<img width="1069" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/183331512-642a3234-92b5-4e7b-9b5a-c5a2b55273b6.png">

### after
<img width="1166" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/183331672-432ebd5b-d1b9-4c1a-8d35-1905eb6e3bd9.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
