### PR TITLE
mobile表示のときのレイアウトの崩れを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -127,7 +127,7 @@ input.how-to-team-select:hover {
 /* Home and Awayの表示 */
 .home-and-away {
   max-width: 10%;
-  height: 1.4rem;
+  height: auto;
   border-radius: 10px;
   @include mobile {
     max-width: 20%;
@@ -193,11 +193,11 @@ $app-color: #6246ea;
 }
 
 .match-data {
-  @tablet {
+  @tablet tablet{
     width: 32rem;
   }
   @include mobile {
-    width: 30rem;
+    width: 23rem;
   }
 }
 
@@ -208,20 +208,19 @@ $app-color: #6246ea;
 /* 対戦予定コンペティションのロゴ */
 .next-match-competition-logo {
     width: 1rem;
-    height: 1.6rem;
-    max-width: 7%;
-  @include mobile {
-    width: 3rem;
-    max-width: 100%;
-  }
+    height: auto;
+    max-width: 10%;
 }
 
 .next-match-venu {
   width: 2rem;
-  height: 1.5rem;
+  height: auto;
   max-width: 100%;
-  border: node;
+  border: none;
   border-radius: 10px;
+  @include mobile {
+    max-width: 20%;
+  }
 }
 
 .match-name {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -158,11 +158,17 @@ input.how-to-team-select:hover {
   }
 }
 
-.box.standing-data {
+.box.standing-and-matches {
   @include mobile {
     width: 24rem;
   }
 }
+
+.box.standing-and-matches:hover {
+  cursor: pointer;
+  opacity: 0.6;
+}
+
 /* /schedulesページ */
 $app-color: #6246ea;
 
@@ -173,11 +179,6 @@ $app-color: #6246ea;
   height: 2rem;
   max-width: 100%;
   border-radius: 10px;
-}
-
-.box.standing-data :hover {
-  cursor: pointer;
-  opacity: 0.6;
 }
 
 .favorite-team-name-and-rank {

--- a/app/javascript/components/page/TeamSchedule/table/TeamMatches.vue
+++ b/app/javascript/components/page/TeamSchedule/table/TeamMatches.vue
@@ -7,9 +7,9 @@
       <img
         :src="match.competition_logo"
         alt="favorite-team-next-match"
-        class="image next-match-competition-logo column is-1" />
+        class="image next-match-competition-logo column my-auto" />
       <p
-        class="next-match-venu column is-2 has-text-white"
+        class="next-match-venu column has-text-white my-auto"
         v-bind:class="
           data.isHome === match.home_and_away
             ? 'has-background-success'
@@ -17,15 +17,15 @@
         ">
         {{ match.home_and_away }}
       </p>
-      <p class="column is-3 next-match-date">
+      <p class="column is-4 next-match-date my-auto">
         {{ matchDay(match.date) }}
       </p>
-      <p class="column is-1 has-text-weight-bold">vs</p>
+      <!--<p class="column has-text-weight-bold my-auto">vs</p>-->
       <img
         :src="match.team_logo"
         alt="match-team-logo"
-        class="image next-match-competition-logo column is-1" />
-      <p class="match-name mobile-display column is-4 has-text-weight-bold">
+        class="image next-match-competition-logo column my-auto" />
+      <p class="match-name mobile-display column has-text-weight-bold my-auto">
         {{ match.team_name }}
       </p>
     </div>

--- a/app/javascript/components/page/TeamSchedule/table/TeamScheduleBox.vue
+++ b/app/javascript/components/page/TeamSchedule/table/TeamScheduleBox.vue
@@ -1,6 +1,8 @@
 <template>
   <div clsss="main-page">
-    <div class="box standing-and-matches columns mb-3" @click="selectTeam(standings)">
+    <div
+      class="box standing-and-matches columns mb-3"
+      @click="selectTeam(standings)">
       <StandingData
         :standings="standings"
         :favoriteTeamPoints="favoriteTeamPoints"

--- a/app/javascript/components/page/TeamSchedule/table/TeamScheduleBox.vue
+++ b/app/javascript/components/page/TeamSchedule/table/TeamScheduleBox.vue
@@ -7,7 +7,7 @@
         :favoriteId="favoriteId"
         class="standing-data column is-three-fifths" />
       <TeamMatches
-        :matchSchedules="matchSchedules"
+        :matchSchedules="matchSchedules.slice(0, 3)"
         class="match-data column is-two-fifths" />
     </div>
     <!--box-standing-and-matches-->

--- a/app/javascript/components/page/TeamSchedule/table/TeamScheduleBox.vue
+++ b/app/javascript/components/page/TeamSchedule/table/TeamScheduleBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div clsss="main-page">
-    <div class="box standing-data columns mb-3" @click="selectTeam(standings)">
+    <div class="box standing-and-matches columns mb-3" @click="selectTeam(standings)">
       <StandingData
         :standings="standings"
         :favoriteTeamPoints="favoriteTeamPoints"
@@ -10,7 +10,7 @@
         :matchSchedules="matchSchedules"
         class="match-data column is-two-fifths" />
     </div>
-    <!--box-standing-data-->
+    <!--box-standing-and-matches-->
   </div>
   <!--manin-page-->
 </template>


### PR DESCRIPTION
## 対応した issue

## 対応内容・対応背景・妥協点

## やったこと
- mobile表示のときのマッチ情報の下線がboxからはみ出ているのを修正した
- 最初の3試合だけ表示されるようにした
- hoverしたときの設定を変更した

## UI before / after
### mobile表示のレイアウトの修正と最初の3試合だけ表示される
#### before
<img width="254" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184322789-c12f972e-f2f6-48a8-ad3a-4d3e74643280.png">

#### after
<img width="168" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184322628-7c951c49-3e00-4f2d-a96b-c617f2d3c4f2.png">

### hoverの設定を修正
#### before
[![Image from Gyazo](https://i.gyazo.com/f7bedaae7c2118e0c7ce26d7e92daf67.gif)](https://gyazo.com/f7bedaae7c2118e0c7ce26d7e92daf67)

#### after
[![Image from Gyazo](https://i.gyazo.com/23a428bf564130ab69c134b090891711.gif)](https://gyazo.com/23a428bf564130ab69c134b090891711)

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
