### PR TITLE
試合詳細ページをリロードできるようにする

### DIFF
--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -1,4 +1,5 @@
 import { createStore } from 'vuex'
+import createPersistedState from 'vuex-persistedstate'
 
 export const store = createStore({
   state() {
@@ -10,5 +11,6 @@ export const store = createStore({
     teamId(state, value) {
       state.teamId = value
     }
-  }
+  },
+  plugins: [createPersistedState({ storage: window.sessionStorage })]
 })

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vue-loader": "^17.0.0",
     "vue-router": "^4.0.14",
     "vuex": "^4.0.2",
+    "vuex-persistedstate": "^4.1.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,6 +2655,11 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz"
@@ -6794,6 +6799,11 @@ shell-quote@^1.6.1:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz"
@@ -7663,6 +7673,14 @@ vue@^3.2.31:
     "@vue/runtime-dom" "3.2.31"
     "@vue/server-renderer" "3.2.31"
     "@vue/shared" "3.2.31"
+
+vuex-persistedstate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"
+  integrity sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## 対応した issue
#208 
## 対応内容・対応背景・妥協点
試合詳細ページでリロードするとstoreのデータが消えるためリロードができない

## やったこと
- vuex-persistedstateをyarnで追加
- storeをセッションに保存できるようにした

## UI before / after
### before
[![Image from Gyazo](https://i.gyazo.com/712c81099456f6c5232712567125a5a8.gif)](https://gyazo.com/712c81099456f6c5232712567125a5a8)

### after
[![Image from Gyazo](https://i.gyazo.com/afb4e960c64407f6bded7e73a8e898eb.gif)](https://gyazo.com/afb4e960c64407f6bded7e73a8e898eb)

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
