### PR TITLE
ページ毎のタイトルを追加した

### DIFF
--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -10,24 +10,39 @@ export const router = createRouter({
   routes: [
     {
       path: '/leagues',
-      component: TeamList
+      component: TeamList,
+      meta: { title: '応援しているチームを登録' }
     },
     {
       path: '/competitors',
-      component: CompetitorTeamSelect
+      component: CompetitorTeamSelect,
+      meta: { title: 'ライバルチームを登録' }
     },
     {
       path: '/schedules',
-      component: TeamSchedule
+      component: TeamSchedule,
+      meta: { title: 'リーグ戦情報' }
     },
     {
       path: '/schedules/:id',
       name: 'show',
-      component: TeamScheduleShowPage
+      component: TeamScheduleShowPage,
+      meta: { title: '試合情報の詳細' }
     },
     {
       path: '/:pathMatch(.*)*',
-      component: NotFound
+      component: NotFound,
+      meta: { title: 'ページが見つかりません' }
     }
   ]
+})
+
+const DEFAULT_TITLE = 'Football MyTeam'
+
+router.afterEach((to) => {
+  const title = to.meta.title
+    ? `${to.meta.title} | ${DEFAULT_TITLE}`
+    : DEFAULT_TITLE
+
+  document.title = title
 })


### PR DESCRIPTION
## 対応した issue
#207
## 対応内容・対応背景・妥協点
各ページごとにタイトルが表示されるようにした
## やったこと
- vue-routerでページごとのタイトルを追加した
- タイトルが読み込まれるようにした

## UI before / after
### before
<img width="209" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184525299-785ed90f-be33-47b4-9ebc-c641a9cc0a82.png">


### after
<img width="253" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184525297-a7573cc1-d89f-4cbc-9b2f-15bd25eacce9.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
