### PR TITLE
試合予定と結果の切り替えに合わせてh2の表記も変わるようにした

### DIFF
--- a/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
@@ -18,7 +18,7 @@
       </div>
       <h2
         class="column is-8 has-text-bold is-size-2 is-size-6-mobile has-text-weight-bold has-text-left my-auto">
-        {{ selectedTeam[0].name }}の試合予定
+        {{ selectedTeam[0].name }}の試合{{ changeTitle }}
       </h2>
     </div>
     <!--selected-team columns -->
@@ -117,6 +117,14 @@ export default {
         })
     }
 
+    const changeTitle = computed(() => {
+      if (data.isActive == 'match_schedule') {
+        return "予定"
+      } else {
+        return "結果"
+      }
+    })
+
     const selectedTeam = computed(() =>
       data.teams.filter((team) => team.id === store.state.teamId)
     )
@@ -146,7 +154,8 @@ export default {
       formatDate,
       matchScheduleFilter,
       matchResultsFilter,
-      selectedTeam
+      selectedTeam,
+      changeTitle
     }
   }
 }

--- a/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
@@ -119,9 +119,9 @@ export default {
 
     const changeTitle = computed(() => {
       if (data.isActive == 'match_schedule') {
-        return "予定"
+        return '予定'
       } else {
-        return "結果"
+        return '結果'
       }
     })
 


### PR DESCRIPTION
## 対応した issue
#213
## 対応内容・対応背景・妥協点
試合詳細の予定と結果を切り替えても、h2の表記が[結果]のままになっていた
## やったこと
h2の表記が変更されるようにした

## UI before / after
### before
[![Image from Gyazo](https://i.gyazo.com/33ccc39002c181728029c3cd2668dc39.gif)](https://gyazo.com/33ccc39002c181728029c3cd2668dc39)

### after
[![Image from Gyazo](https://i.gyazo.com/1d1113fcfab54af8abc6274a2e8a2ec9.gif)](https://gyazo.com/1d1113fcfab54af8abc6274a2e8a2ec9)

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
