### PR TITLE
バッジ処理を追加してAPIリクエストをするタイミングを固定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,4 @@ gem 'html2slim'
 gem 'slim-rails'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -311,6 +312,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
@@ -356,6 +359,7 @@ DEPENDENCIES
   web-console (>= 4.1.0)
   webdrivers
   webpacker (~> 5.0)
+  whenever
 
 RUBY VERSION
    ruby 3.1.1p18

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class API::MatchesController < ApplicationController
-  before_action :set_match
   before_action :set_show_page, only: [:show]
 
   def index
@@ -16,29 +15,5 @@ class API::MatchesController < ApplicationController
 
   def set_show_page
     @team_id = Team.find(params[:id])
-  end
-
-  def set_match
-    Match.delete_all
-    MatchRequest.league(api_request_url)
-  end
-
-  def api_request_url
-    api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
-    api_id.map do |i|
-      URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}")
-    end
-  end
-
-  def match_date
-    '2022-02-30&to=2022-03-30'
-  end
-
-  def current_season
-    '2021'
-  end
-
-  def competitor_teams
-    SelectTeam.competitor(current_user)
   end
 end

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -2,6 +2,7 @@
 
 class API::MatchesController < ApplicationController
   before_action :set_show_page, only: [:show]
+  before_action :match_api_request
 
   def index
     @match = Match.all.order(:date).where(date: Time.zone.today..)
@@ -15,5 +16,25 @@ class API::MatchesController < ApplicationController
 
   def set_show_page
     @team_id = Team.find(params[:id])
+  end
+
+  def match_api_request
+    set_match if Match.all.blank?
+  end
+
+  def set_match
+    Match.delete_all
+    MatchRequest.league(api_request_url)
+  end
+
+  def api_request_url
+    api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
+    api_id.map do |i|
+      URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}")
+    end
+  end
+
+  def competitor_teams
+    SelectTeam.competitor(current_user)
   end
 end

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -2,10 +2,40 @@
 
 class API::StandingsController < ApplicationController
   before_action :authenticate_user!
+  before_action :api_request
 
   def index
     @standing = Standing.all
   end
 
   def show; end
+
+  private
+
+  def api_request
+    set_standing if Standing.all.blank?
+  end
+
+  def set_standing
+    Standing.delete_all
+    StandingRequest.league(api_request_url)
+  end
+
+  def api_request_url
+    team_numbers = competitor_team_api_id.unshift(favorite_team.api_id)
+    team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id(favorite_team)}&season=#{Year.season}&team=#{number}") }
+  end
+
+  def competitor_team_api_id
+    SelectTeam.competitor(current_user)
+  end
+
+  def league_api_id(favorite_team)
+    league = League.find(favorite_team.league_id)
+    league.api_id
+  end
+
+  def favorite_team
+    current_user.favorite.team
+  end
 end

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class API::StandingsController < ApplicationController
-  before_action :api_request
   before_action :authenticate_user!
 
   def index
@@ -9,29 +8,4 @@ class API::StandingsController < ApplicationController
   end
 
   def show; end
-
-  private
-
-  def api_request
-    Standing.delete_all
-    StandingRequest.league(api_request_url)
-  end
-
-  def api_request_url
-    team_numbers = competitor_team_api_id.unshift(favorite_team.api_id)
-    team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id(favorite_team)}&season=#{Year.season}&team=#{number}") }
-  end
-
-  def competitor_team_api_id
-    SelectTeam.competitor(current_user)
-  end
-
-  def league_api_id(favorite_team)
-    league = League.find(favorite_team.league_id)
-    league.api_id
-  end
-
-  def favorite_team
-    current_user.favorite.team
-  end
 end

--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class API::UpdateMatchesController < ApplicationController
+  before_action :set_match
+
+  def index
+    @match = Match.all.order(:date).where(date: Time.zone.today..)
+  end
+
+  private
+
+  def set_show_page
+    @team_id = Team.find(params[:id])
+  end
+
+  def set_match
+    Match.delete_all
+    MatchRequest.league(api_request_url)
+  end
+
+  def api_request_url
+    api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
+    api_id.map do |i|
+      URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}")
+    end
+  end
+
+  def competitor_teams
+    SelectTeam.competitor(current_user)
+  end
+end

--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -2,14 +2,19 @@
 
 class API::UpdateMatchesController < ApplicationController
   before_action :set_match
+  before_action :authenticate_user!
 
   def index
     @match = Match.all.order(:date).where(date: Time.zone.today..)
   end
 
+  def batch_request
+    api_request
+  end
+
   private
 
-  def set_match
+  def api_request
     Match.delete_all
     MatchRequest.league(api_request_url)
   end

--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -9,10 +9,6 @@ class API::UpdateMatchesController < ApplicationController
 
   private
 
-  def set_show_page
-    @team_id = Team.find(params[:id])
-  end
-
   def set_match
     Match.delete_all
     MatchRequest.league(api_request_url)

--- a/app/controllers/api/update_standings_controller.rb
+++ b/app/controllers/api/update_standings_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class API::UpdateStandingsController < ApplicationController
+  before_action :api_request
+  before_action :authenticate_user!
+
+  def index
+    @standing = Standing.all
+  end
+
+  private
+
+  def api_request
+    Standing.delete_all
+    StandingRequest.league(api_request_url)
+  end
+
+  def api_request_url
+    team_numbers = competitor_team_api_id.unshift(favorite_team.api_id)
+    team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id(favorite_team)}&season=#{Year.season}&team=#{number}") }
+  end
+
+  def competitor_team_api_id
+    SelectTeam.competitor(current_user)
+  end
+
+  def league_api_id(favorite_team)
+    league = League.find(favorite_team.league_id)
+    league.api_id
+  end
+
+  def favorite_team
+    current_user.favorite.team
+  end
+end

--- a/app/controllers/api/update_standings_controller.rb
+++ b/app/controllers/api/update_standings_controller.rb
@@ -8,6 +8,10 @@ class API::UpdateStandingsController < ApplicationController
     @standing = Standing.all
   end
 
+  def batch_request
+    api_request
+  end
+
   private
 
   def api_request

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -12,6 +12,7 @@
       <div v-else>
         <div class="mb-3 has-text-right">
           <p>更新日:{{ updateDate(favoriteMatches[0].created_at) }}</p>
+          <button class="button my-1" @click="dataUpdate">更新する</button>
         </div>
         <TeamScheduleBox
           :standings="data.favoriteTeams"
@@ -124,6 +125,41 @@ export default {
         })
     }
 
+    const updateMatches = async () => {
+      await axios
+        .get('/api/update_matches')
+        .then((response) => {
+          data.matches = response.data
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
+    }
+
+    const updateStadings = async () => {
+      await axios
+        .get('/api/standings')
+        .then((response) => {
+          data.favoriteTeams = response.data[0]
+          data.favoriteTeamPoints = data.favoriteTeams.points
+          data.firstCompetitorTeams = response.data[1]
+          data.secondCompetitorTeams = response.data[2]
+          data.thirdCompetitorTeams = response.data[3]
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
+    }
+
+    const resetMatchesAndStandings = () => {
+      data.matches = []
+      data.favoriteTeams = []
+      data.favoriteTeamPoints = []
+      data.firstCompetitorTeams = []
+      data.secondCompetitorTeams = []
+      data.thirdCompetitorTeams = []
+    }
+
     const toDoubleDigits = function (num) {
       num += ''
       if (num.length === 1) {
@@ -141,6 +177,12 @@ export default {
       const hh = toDoubleDigits(getDate.getHours())
       const min = toDoubleDigits(getDate.getMinutes())
       return `${mm}/${dd}(${week})${hh}:${min}`
+    }
+
+    const dataUpdate = async () => {
+      resetMatchesAndStandings()
+      updateMatches()
+      updateStadings()
     }
 
     const favoriteMatches = computed(() =>
@@ -189,6 +231,10 @@ export default {
       thirdCompetitorTeamsMatches,
       toDoubleDigits,
       updateDate,
+      dataUpdate,
+      resetMatchesAndStandings,
+      updateMatches,
+      updateStadings,
       date,
       formatDate,
       gameCount

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -10,6 +10,9 @@
       </p>
       <MatchListLoader v-if="firstCompetitorTeamsMatches.length === 0" />
       <div v-else>
+        <div class="mb-3 has-text-right">
+          <p>更新日:{{ updateDate(favoriteMatches[0].created_at) }}</p>
+        </div>
         <TeamScheduleBox
           :standings="data.favoriteTeams"
           :matchSchedules="favoriteMatches"
@@ -121,6 +124,25 @@ export default {
         })
     }
 
+    const toDoubleDigits = function (num) {
+      num += ''
+      if (num.length === 1) {
+        num = '0' + num
+      }
+      return num
+    }
+
+    const updateDate = (date) => {
+      const weekDay = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fry', 'Sat']
+      const getDate = new Date(date)
+      const mm = String(getDate.getMonth() + 1).padStart(2, '0')
+      const dd = String(getDate.getDate()).padStart(2, '0')
+      const week = weekDay[getDate.getDay()]
+      const hh = toDoubleDigits(getDate.getHours())
+      const min = toDoubleDigits(getDate.getMinutes())
+      return `${mm}/${dd}(${week})${hh}:${min}`
+    }
+
     const favoriteMatches = computed(() =>
       data.matches.filter((f) => f.team_matches_index === data.favorite.team.id)
     )
@@ -165,6 +187,8 @@ export default {
       firstCompetitorTeamsMatches,
       secondCompetitorTeamsMatches,
       thirdCompetitorTeamsMatches,
+      toDoubleDigits,
+      updateDate,
       date,
       formatDate,
       gameCount

--- a/app/views/api/matches/index.json.jbuilder
+++ b/app/views/api/matches/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away
+json.array! @match, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at

--- a/app/views/api/update_matches/index.json.jbuilder
+++ b/app/views/api/update_matches/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @match, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at

--- a/app/views/api/update_standings/index.json.jbuilder
+++ b/app/views/api/update_standings/index.json.jbuilder
@@ -1,0 +1,2 @@
+json.array! @standing, :team_id, :team_name, :team_logo, :rank, :points, :played
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     resources :standings, only: [:index, :show]
     resources :team_filter, only: [:index]
     resources :matches, only: [:index, :show]
+    resources :update_matches, only: [:index]
+    resources :update_standings, only: [:index]
   end
   get 'privacy_policy', to: 'home#privacy_policy', as: 'privacy_policy'
   get 'terms_of_service', to: 'home#terms_of_service', as: 'terms_of_service'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,27 +1,6 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
-
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
-
-every :sunday, at: '11:40 am' do # Use any day of the week or :weekend, :weekday
-  update_mateches = UpdateMatches.new
-  update_standings = UpdateStandings.new
-  runner "update_mateches.set_match"
+every 1.day, at: '5am' do
+  update_standings = API::UpdateStandingsController.new
   runner "update_standings.api_request"
+  update_matches = API::UpdateMatchesController.new
+  runner "update_matches.api_request"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,27 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every :sunday, at: '11:40 am' do # Use any day of the week or :weekend, :weekday
+  update_mateches = UpdateMatches.new
+  update_standings = UpdateStandings.new
+  runner "update_mateches.set_match"
+  runner "update_standings.api_request"
+end

--- a/spec/requests/api/update_matches_spec.rb
+++ b/spec/requests/api/update_matches_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API::UpdateMatches', type: :request do
+  describe 'GET /update_matches/index' do
+    it 'returns http success' do
+      league = FactoryBot.create(:league)
+      team = FactoryBot.create(:team, league: league)
+      user = FactoryBot.build(:user)
+      sign_in user
+      user.favorite_team_follow(team)
+      get api_matches_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/api/update_standings_spec.rb
+++ b/spec/requests/api/update_standings_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe 'API::Standings', type: :request do
-  describe 'GET /api/standings/index' do
+RSpec.describe 'API::UpdateStandings', type: :request do
+  describe 'GET /update_standings/index' do
     it 'returns http success' do
       league = FactoryBot.create(:league)
       team1 = FactoryBot.create(:team, :arsenal, league: league)


### PR DESCRIPTION
## 対応した issue
#194 
## 対応内容・対応背景・妥協点
現状はアクセスするたびにAPIを叩く状態になっている。
時間がかかるし、リクエス数も無駄に増えるため修正が必要だと判断した。

## やったこと
- 更新日時が表示されるようにした
- ボタンで情報を更新できるようにした
- アクセスするたびに情報が更新される設定を無くした
- バッジ処理を追加

## UI before / after
変わりなし
## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
