### PR TITLE
メソッド名が間違っていたため500エラーが出ていたため修正

### DIFF
--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::UpdateMatchesController < ApplicationController
-  before_action :set_match
+  before_action :api_request
   before_action :authenticate_user!
 
   def index


### PR DESCRIPTION
## 対応した issue
#216 

