### PR TITLE
バーガーメニューを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -272,3 +272,7 @@ $button-color: #6246ea;
 .tab-contents .content.is-active {
   display: block;
 }
+
+.burger-menu-item {
+  text-align: center;
+}

--- a/app/javascript/head.js
+++ b/app/javascript/head.js
@@ -1,0 +1,39 @@
+// document.addEventListener('DOMContentLoaded', () => {
+//   // ナビゲーションバーガー（navbar-burgerクラスを持つすべての要素）を取得します。
+//   const $navbarBurgers = document.querySelectorAll('.navbar-burger')
+//   console.log($navbarBurgers)
+//   // ナビゲーションバーガーがあるかどうかを確認します。
+//   if ($navbarBurgers.length > 0) {
+//     // すべてのナビゲーションバーガーをループします。
+//     $navbarBurgers.forEach(el => {
+//       // ナビゲーションバーガーにクリックイベントを追加します。
+//       el.addEventListener('click', () => {
+//         // ナビゲーションバーガーのdata-target属性の値を取得します。
+//         const target = el.dataset.target
+//         // メニュー（data-target属性の値をIDとして持つ要素）を取得します。
+//         const $target = document.getElementById(target)
+//         // ナビゲーションバーガーでis-activeクラスを切り替えます。
+//         el.classList.toggle('is-active')
+//         // メニューでis-activeクラスを切り替えます。
+//         $target.classList.toggle('is-active')
+//       })
+//     })
+//   }
+// })
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Get all "navbar-burger" elements
+  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0)
+
+  // Add a click event on each of them
+  $navbarBurgers.forEach(el => {
+    el.addEventListener('click', () => {
+      // Get the target from the "data-target" attribute
+      const target = el.dataset.target
+      const $target = document.getElementById(target)
+      // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
+      el.classList.toggle('is-active')
+      $target.classList.toggle('is-active')
+    })
+  })
+})

--- a/app/javascript/head.js
+++ b/app/javascript/head.js
@@ -23,10 +23,13 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   // Get all "navbar-burger" elements
-  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0)
+  const $navbarBurgers = Array.prototype.slice.call(
+    document.querySelectorAll('.navbar-burger'),
+    0
+  )
 
   // Add a click event on each of them
-  $navbarBurgers.forEach(el => {
+  $navbarBurgers.forEach((el) => {
     el.addEventListener('click', () => {
       // Get the target from the "data-target" attribute
       const target = el.dataset.target

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,6 +5,7 @@
 
 import Rails from '@rails/ujs'
 import 'main.js'
+import 'head.js'
 import * as ActiveStorage from '@rails/activestorage'
 
 Rails.start()

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,19 +15,27 @@ html
     header
       .navbar.is-transparent.is-fixed-top.p-2.has-background-main
         .navbar-brand
-          .title
+          .title.my-auto
             = link_to root_path do
               = image_tag('football_logo.svg', alt: 'football_myteam_logo', class: 'image title-logo')
-        .navbar-menu
-          .navbar-end
-            .navbar-item.has-text-white.mx-2
-              - if user_signed_in?
-                = link_to '登録しているチームを変更する', '/leagues', class: 'has-text-white mx-2'
-                = link_to 'プロフィール変更', edit_user_registration_path, class: 'has-text-white mx-2'
-                = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'has-text-white mx-2'
-              - else
-                = link_to 'アカウントを作成', new_user_registration_path, class: 'has-text-white mx-2'
-                = link_to 'ログイン', new_user_session_path, class: 'has-text-white mx-2'
+          a.navbar-burger.has-text-white role="button" aria-label="menu" aria-expanded="false" data-target="targetMenu"
+            span aria-hidden="true"
+              |
+            span aria-hidden="true"
+              |
+            span aria-hidden="true"
+              |
+        .navbar-end
+          #targetMenu.navbar-menu.has-background-main
+            - if user_signed_in?
+                = link_to 'チームを変更する', '/leagues', class: 'burger-menu-item navbar-item has-text-white'
+                = link_to 'プロフィール変更', edit_user_registration_path, class: 'burger-menu-item navbar-item has-text-white'
+                = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item has-text-white'
+            - else
+              .navbar-item
+                = link_to 'アカウントを作成', new_user_registration_path
+              .navbar-item
+                = link_to 'ログイン', new_user_session_path
       p
         .notice.is-size-4.p-5.has-text-centered.has-text-info
           = notice

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,17 +25,19 @@ html
               |
             span aria-hidden="true"
               |
-        .navbar-end
-          #targetMenu.navbar-menu.has-background-main
+        #targetMenu.navbar-menu.has-background-main
+          .navbar-start
             - if user_signed_in?
                 = link_to 'チームを変更する', '/leagues', class: 'burger-menu-item navbar-item has-text-white'
                 = link_to 'プロフィール変更', edit_user_registration_path, class: 'burger-menu-item navbar-item has-text-white'
-                = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item has-text-white'
+          .navbar-end
+            - if user_signed_in?
+                = link_to 'Logout', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item button'
             - else
               .navbar-item
-                = link_to 'アカウントを作成', new_user_registration_path
+                = link_to 'Sign up', new_user_registration_path, class: 'burger-menu-item navbar-item button'
               .navbar-item
-                = link_to 'ログイン', new_user_session_path
+                = link_to 'Login', new_user_session_path, class: 'burger-menu-item navbar-item button'
       p
         .notice.is-size-4.p-5.has-text-centered.has-text-info
           = notice

--- a/spec/system/favorite_team_select_spec.rb
+++ b/spec/system/favorite_team_select_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe '応援しているチームを登録する', type: :system, js: 
     FactoryBot.create(:team, :sassuolo, league: serie_a)
 
     visit root_path
-    first('.button').click_link 'アカウント作成'
+    all('.button')[2].click_link 'アカウント作成'
     fill_in 'Eメール', with: 'fjord2022@example.com'
     fill_in 'パスワード', with: '123456'
     fill_in 'パスワード（確認用）', with: '123456'

--- a/spec/system/not_found_spec.rb
+++ b/spec/system/not_found_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'NotFoundPage', type: :system, js: true do
   it 'display 404 page', js: true do
     visit root_path
 
-    first('.button').click_link 'アカウント作成'
+    all('.button')[2].click_link 'アカウント作成'
     fill_in 'Eメール', with: 'fjord2022@example.com'
     fill_in 'パスワード', with: '123456'
     fill_in 'パスワード（確認用）', with: '123456'

--- a/spec/system/signin_and_signup_spec.rb
+++ b/spec/system/signin_and_signup_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'devise', type: :system, js: true do
     FactoryBot.create(:favorite, user: user, team: team1)
     FactoryBot.create(:competitor, user: user, team: team2)
 
-    all('.button')[1].click_link 'ログイン'
+    all('.button')[3].click_link 'ログイン'
     fill_in 'Eメール', with: user.email
     fill_in 'パスワード', with: user.password
     click_button 'ログイン'
@@ -25,7 +25,7 @@ RSpec.describe 'devise', type: :system, js: true do
   end
 
   it 'email error when login.', js: true do
-    all('.button')[1].click_link 'ログイン'
+    all('.button')[3].click_link 'ログイン'
     fill_in 'Eメール', with: 'error@example.com'
     fill_in 'パスワード', with: user.password
     click_button 'ログイン'
@@ -34,7 +34,7 @@ RSpec.describe 'devise', type: :system, js: true do
   end
 
   it 'password error when login.', js: true do
-    all('.button')[1].click_link 'ログイン'
+    all('.button')[3].click_link 'ログイン'
     fill_in 'Eメール', with: user.email
     fill_in 'パスワード', with: 'xxxxxx'
     click_button 'ログイン'
@@ -43,7 +43,7 @@ RSpec.describe 'devise', type: :system, js: true do
   end
 
   it 'user create new account', js: true do
-    first('.button').click_link 'アカウント作成'
+    all('.button')[2].click_link 'アカウント作成'
     fill_in 'Eメール', with: 'fjord2022@example.com'
     fill_in 'パスワード', with: '123456'
     fill_in 'パスワード（確認用）', with: '123456'
@@ -53,7 +53,7 @@ RSpec.describe 'devise', type: :system, js: true do
   end
 
   it 'password validation enabled during account creation', js: true do
-    first('.button').click_link 'アカウント作成'
+    all('.button')[2].click_link 'アカウント作成'
     fill_in 'Eメール', with: 'abc@example.com'
     fill_in 'パスワード', with: '1234'
     fill_in 'パスワード（確認用）', with: '1234'


### PR DESCRIPTION
## 対応した issue
#182 
## 対応内容・対応背景・妥協点
PCサイズ以外のときにヘッダーのメニューが使えなくなっていたのでバーガーメニューを追加
## やったこと
- バーガーメニュー用のjsファイルを作成
- バーガーメニューを作成
- ヘッダーのレイアウトを修正

## UI before / after
### トップページ
#### before
<img width="1426" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184796871-3c8ba403-5518-45e3-aefd-667ec044bd1d.png">


#### after
<img width="1454" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184796891-86a6756a-4079-4316-875d-a1884b04275b.png">

### バーガーメニュー
#### before
<img width="985" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184796841-5ae49a22-6b51-4583-bec0-bff9b27d592d.png">


#### after
<img width="1001" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/184796807-3d9455e8-9005-45e4-99b7-4db7d7056393.png">

<img width="990" alt="リーグ戦情報___Football_MyTeam_と_Dockerで使うコマンド_-_Inkdrop" src="https://user-images.githubusercontent.com/62058863/184796771-b449fdfe-b8da-4d91-b1c4-b28795f6e95d.png">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
