### PR TITLE
デザインレビューの修正2

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -223,20 +223,16 @@ $app-color: #6246ea;
 
 /* 対戦予定コンペティションのロゴ */
 .next-match-competition-logo {
-    width: 1rem;
-    height: auto;
-    max-width: 10%;
+    width: 3rem;
 }
 
 .next-match-venu {
-  width: 2rem;
-  height: auto;
-  max-width: 100%;
-  border: none;
+  width: 4rem;
   border-radius: 10px;
-  @include mobile {
-    max-width: 20%;
-  }
+}
+
+.next-match-date {
+  width: 6rem;
 }
 
 .match-name {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -176,9 +176,13 @@ $app-color: #6246ea;
 .favorite-team-tag {
   background-color: $app-color;
   width: 4.5rem;
-  height: 2rem;
   max-width: 100%;
+  height: 2rem;
   border-radius: 10px;
+}
+
+.favorite-team-tag-text {
+  padding-top: 0.2rem;
 }
 
 .favorite-team-name-and-rank {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,17 @@ main {
 .team-logo {
   width: 5rem;
   max-width: 100%;
+  @include mobile {
+    max-width: 80%;
+  }
+}
+
+.selected-team-logo-show-page {
+  width: 4rem;
+  max-width: 100%;
+  @include mobile {
+    max-width: 80%;
+  }
 }
 
 .standings-team-logo {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -257,7 +257,6 @@ $app-color: #6246ea;
   }
 }
 
-
 /* ボタン */
 $button-color: #6246ea;
 
@@ -269,8 +268,13 @@ $button-color: #6246ea;
 .tab-contents .content {
   display: none;
 }
+
 .tab-contents .content.is-active {
   display: block;
+}
+
+.schedule-column-logo {
+  padding: 0;
 }
 
 .burger-menu-item {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "bulma";
 
-/* layout */
 $main: #6246ea;
+$border-color: #DDD;
 
 body {
   display: flex;
@@ -88,7 +88,6 @@ main {
     max-width: 100%;
   }
 }
-
 
 /* リーグまたはチーム選択時 */
 .select-button {
@@ -197,15 +196,15 @@ $app-color: #6246ea;
 }
 
 .favorite-team-name-and-rank {
-  border-right: solid 1px;
+  border-right: solid 1px $border-color;
 }
 
 .favorite-team-points {
-  border-right: solid 1px;
+  border-right: solid 1px $border-color;
 }
 
 .favorite-team-played {
-  border-right: solid 1px;
+  border-right: solid 1px $border-color;
 }
 
 .match-data {
@@ -218,7 +217,7 @@ $app-color: #6246ea;
 }
 
 .next-match {
-  border-bottom: solid 1px;
+  border-bottom: solid 1px $border-color;
 }
 
 /* 対戦予定コンペティションのロゴ */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -287,6 +287,10 @@ $button-color: #6246ea;
   padding: 0;
 }
 
+.schedule-column-score {
+  padding: 0;
+}
+
 .burger-menu-item {
   text-align: center;
 }

--- a/app/javascript/components/atoms/FavoriteTeamTag.vue
+++ b/app/javascript/components/atoms/FavoriteTeamTag.vue
@@ -1,3 +1,5 @@
 <template>
-  <p class="favorite-team-tag has-text-white">MyTeam</p>
+  <div class="favorite-team-tag has-text-centered">
+    <p class="favorite-team-tag-text has-text-white">MyTeam</p>
+  </div>
 </template>

--- a/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
@@ -1,25 +1,25 @@
 <template>
-  <div class="container pt-5">
+  <div class="container">
     <h2
-      class="selected-team is-mobile is-gapless is-flex is-justify-content-center is-align-items-center mx-auto mb-6"
+      class="selected-team is-flex is-justify-content-center is-align-items-center mx-auto mb-2"
       v-if="selectedTeam[0]">
       <span
-        class="is-2 m-auto"
+        class="favorite-team-tag my-auto mr-2"
         v-if="
           data.favorite.team && data.favorite.team.id === $store.state.teamId
         ">
         <FavoriteTeamTag />
       </span>
-      <div class="column is-2">
+      <div class="mr-2">
         <img
           :src="selectedTeam[0].logo"
           alt="selected_team_logo"
-          class="image team-logo m-auto" />
-      </div><!-- column -->
+          class="image selected-team-logo-show-page m-auto" />
+      </div><!-- mr-2.selected-team-togo-show-page -->
       <div
-        class="is-8 has-text-bold is-size-2 is-size-6-mobile has-text-weight-bold has-text-left my-auto">
+        class="selected-team-name-and-matches has-text-bold is-size-2 is-size-6-mobile has-text-weight-bold has-text-left my-auto">
         {{ selectedTeam[0].name }}の試合{{ changeTitle }}
-      </div><!-- is-8 -->
+      </div><!-- selected-team-name-and-matches -->
     </h2><!--selected-team -->
     <div class="tabs is-toggle is-centered">
       <ul>

--- a/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
@@ -15,12 +15,15 @@
           :src="selectedTeam[0].logo"
           alt="selected_team_logo"
           class="image selected-team-logo-show-page m-auto" />
-      </div><!-- mr-2.selected-team-togo-show-page -->
+      </div>
+      <!-- mr-2.selected-team-togo-show-page -->
       <div
         class="selected-team-name-and-matches has-text-bold is-size-2 is-size-6-mobile has-text-weight-bold has-text-left my-auto">
         {{ selectedTeam[0].name }}の試合{{ changeTitle }}
-      </div><!-- selected-team-name-and-matches -->
-    </h2><!--selected-team -->
+      </div>
+      <!-- selected-team-name-and-matches -->
+    </h2>
+    <!--selected-team -->
     <div class="tabs is-toggle is-centered">
       <ul>
         <li v-bind:class="{ 'is-active': data.isActive == 'match_schedule' }">

--- a/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
@@ -1,27 +1,26 @@
 <template>
   <div class="container pt-5">
-    <div
-      class="selected-team columns is-mobile is-gapless mx-auto has-text-centered"
+    <h2
+      class="selected-team is-mobile is-gapless is-flex is-justify-content-center is-align-items-center mx-auto mb-6"
       v-if="selectedTeam[0]">
-      <div
-        class="column is-2 m-auto"
+      <span
+        class="is-2 m-auto"
         v-if="
           data.favorite.team && data.favorite.team.id === $store.state.teamId
         ">
         <FavoriteTeamTag />
-      </div>
+      </span>
       <div class="column is-2">
         <img
           :src="selectedTeam[0].logo"
           alt="selected_team_logo"
           class="image team-logo m-auto" />
-      </div>
-      <h2
-        class="column is-8 has-text-bold is-size-2 is-size-6-mobile has-text-weight-bold has-text-left my-auto">
+      </div><!-- column -->
+      <div
+        class="is-8 has-text-bold is-size-2 is-size-6-mobile has-text-weight-bold has-text-left my-auto">
         {{ selectedTeam[0].name }}の試合{{ changeTitle }}
-      </h2>
-    </div>
-    <!--selected-team columns -->
+      </div><!-- is-8 -->
+    </h2><!--selected-team -->
     <div class="tabs is-toggle is-centered">
       <ul>
         <li v-bind:class="{ 'is-active': data.isActive == 'match_schedule' }">

--- a/app/javascript/components/page/TeamSchedule/list/MatchResultList.vue
+++ b/app/javascript/components/page/TeamSchedule/list/MatchResultList.vue
@@ -31,9 +31,10 @@
           class="column m-auto has-text-centered has-text-weight-bold is-size-3-tablet mobile-display">
           {{ result.home_team_name }}
         </p>
-        <div class="column m-auto">
+        <div class="column m-auto schedule-column-logo">
           <img :src="result.home_logo" class="image team-logo m-auto" />
         </div>
+        <!-- schedule-column-logo -->
         <p
           class="column has-text-centered has-text-weight-bold is-size-1 is-size-3-mobile m-auto">
           {{ result.home_score }}
@@ -46,9 +47,10 @@
           class="column has-text-centered has-text-weight-bold is-size-1 is-size-3-mobile m-auto">
           {{ result.away_score }}
         </p>
-        <div class="column m-auto">
+        <div class="column m-auto schedule-column-logo">
           <img :src="result.away_logo" class="image team-logo m-auto" />
         </div>
+        <!-- schedule-column-logo -->
         <p
           class="column has-text-centered has-text-weight-bold m-auto is-size-3-tablet mobile-display">
           {{ result.away_team_name }}

--- a/app/javascript/components/page/TeamSchedule/list/MatchResultList.vue
+++ b/app/javascript/components/page/TeamSchedule/list/MatchResultList.vue
@@ -31,20 +31,20 @@
           class="column m-auto has-text-centered has-text-weight-bold is-size-3-tablet mobile-display">
           {{ result.home_team_name }}
         </p>
-        <div class="column m-auto schedule-column-logo">
+        <div class="column schedule-column-logo m-auto">
           <img :src="result.home_logo" class="image team-logo m-auto" />
         </div>
         <!-- schedule-column-logo -->
         <p
-          class="column has-text-centered has-text-weight-bold is-size-1 is-size-3-mobile m-auto">
+          class="column schedule-column-score has-text-centered has-text-weight-bold is-size-1 is-size-3-mobile m-auto">
           {{ result.home_score }}
         </p>
         <p
-          class="column has-text-centered has-text-weight-bold is-size-3 is-size-5-mobile m-auto">
+          class="column schedule-column-score has-text-centered has-text-weight-bold is-size-3 is-size-5-mobile m-auto">
           -
         </p>
         <p
-          class="column has-text-centered has-text-weight-bold is-size-1 is-size-3-mobile m-auto">
+          class="column schedule-column-score has-text-centered has-text-weight-bold is-size-1 is-size-3-mobile m-auto">
           {{ result.away_score }}
         </p>
         <div class="column m-auto schedule-column-logo">

--- a/app/javascript/components/page/TeamSchedule/table/TeamMatches.vue
+++ b/app/javascript/components/page/TeamSchedule/table/TeamMatches.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="favorite-team-schedules">
+  <div class="favorite-team-schedules py-0">
     <div
-      class="next-match columns is-mobile is-gapless has-text-centered is-size-5-mobile"
+      class="next-match has-text-centered is-size-5-mobile is-flex is-align-items-center py-2"
       v-for="match in matchSchedules"
       :key="match.id">
       <img
         :src="match.competition_logo"
         alt="favorite-team-next-match"
-        class="image next-match-competition-logo column my-auto" />
+        class="image next-match-competition-logo" />
       <p
-        class="next-match-venu column has-text-white my-auto"
+        class="next-match-venu has-text-white mr-1"
         v-bind:class="
           data.isHome === match.home_and_away
             ? 'has-background-success'
@@ -17,19 +17,21 @@
         ">
         {{ match.home_and_away }}
       </p>
-      <p class="column is-4 next-match-date my-auto">
+      <!-- next-match-venu -->
+      <p class="next-match-date">
         {{ matchDay(match.date) }}
       </p>
-      <!--<p class="column has-text-weight-bold my-auto">vs</p>-->
+      <!-- next-match-date -->
       <img
         :src="match.team_logo"
         alt="match-team-logo"
-        class="image next-match-competition-logo column my-auto" />
-      <p class="match-name mobile-display column has-text-weight-bold my-auto">
+        class="image next-match-competition-logo" />
+      <p class="match-name mobile-display has-text-weight-bold">
         {{ match.team_name }}
       </p>
+      <!-- match-name -->
     </div>
-    <!-- next-match columns -->
+    <!-- next-match -->
   </div>
   <!-- favorite-team-schedules -->
 </template>


### PR DESCRIPTION
## 対応した issue
#222 
## 対応内容・対応背景・妥協点
- レイアウトがズレていた
## やったこと
- メインページの試合予定のスペースを修正
- 試合詳細ページの登録したチーム名がセンターに来るように修正
- 試合詳細ページの試合結果で表示されるロゴのサイズを修正

## UI before / after
### メインページ
#### before
<img width="1129" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185156957-9f91598c-a4c7-41be-a584-52f27641fd58.png">

#### after
<img width="1187" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185156888-78d27930-1c4c-472b-9188-2f7e611f15b5.png">

### 試合詳細
### before
<img width="462" alt="試合情報の詳細___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185157190-4123a1dc-759b-4eb3-8191-b396edd5d87b.png">

### after

<img width="319" alt="試合情報の詳細___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185157137-b6f6c9b4-7b28-4c35-8c02-aa1592c55e0a.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
