### PR TITLE
スマホサイズのときにマージンを入れるようにした

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -232,6 +232,9 @@ $app-color: #6246ea;
 
 .next-match-date {
   width: 6rem;
+  @include mobile {
+    margin-right: 0.75rem;
+  }
 }
 
 .match-name {


### PR DESCRIPTION
## 対応した issue
#224 

## UI before / after
### before

<img width="417" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185171930-03fc6165-f230-4988-9ea6-6f5e070461f9.png">

### after
<img width="323" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185171701-c9fa2788-02b4-43f7-b13f-ba9aa0eae900.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
