### PR TITLE
Deviseで表示するページのレイアウトを修正

### DIFF
--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,11 +1,13 @@
-h2
-  | Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render 'devise/shared/error_messages', resource: resource
-  .field
-    = f.label :email
-  br
-  = f.email_field :email, autofocus: true, autocomplete: 'email'
-  .actions
-    = f.submit 'Send me reset password instructions'
-= render 'devise/shared/links'
+.container
+  .section
+    h2.is-size-2.is-size-4-mobile.has-text-weight-semibold.has-text-centered.mb-3
+      | パスワードを変更する
+    = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+      = render 'devise/shared/error_messages', resource: resource
+      .field.has-text-left.has-text-weight-medium
+        = f.label :email
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'football-myteam@example.com'
+      .actions.has-text-centered
+        = f.submit 'パスワードをリセットする', class: 'is-size-5 is-size-7-mobile color-button button is-rounded is-medium has-text-white mt-3'
+    .has-text-right.has-text-weight-medium
+      = render 'devise/shared/links'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,19 +1,20 @@
-.container.pt-5
-  h2.is-size-2.is-size-4-mobile.has-text-weight-semibold.has-text-centered
-    | アカウントを作成
-  = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-    = render 'devise/shared/error_messages', resource: resource
-    .field.has-text-left.has-text-weight-medium
-      = f.label :email
-      = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
-    .field.has-text-left.has-text-weight-medium
-      = f.label :password
-      - if @minimum_password_length
-        = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "#{@minimum_password_length}文字以上入力してください"
-    .field.has-text-left.has-text-weight-medium
-      = f.label :password_confirmation
-      = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: "#{@minimum_password_length}文字以上入力してください"
-    .actions.has-text-centered
-      = f.submit t('.sign_up'), class: 'color-button button is-rounded is-medium has-text-white'
-  .has-text-right.has-text-weight-medium
-    = render 'devise/shared/links'
+.container
+  .section
+    h2.is-size-2.is-size-4-mobile.has-text-weight-semibold.has-text-centered
+      | アカウントを作成
+    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      = render 'devise/shared/error_messages', resource: resource
+      .field.has-text-left.has-text-weight-medium
+        = f.label :email
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
+      .field.has-text-left.has-text-weight-medium
+        = f.label :password
+        - if @minimum_password_length
+          = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "#{@minimum_password_length}文字以上入力してください"
+      .field.has-text-left.has-text-weight-medium
+        = f.label :password_confirmation
+        = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: "#{@minimum_password_length}文字以上入力してください"
+      .actions.has-text-centered
+        = f.submit t('.sign_up'), class: 'color-button button is-rounded is-medium has-text-white'
+    .has-text-right.has-text-weight-medium
+      = render 'devise/shared/links'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -6,7 +6,7 @@
       = render 'devise/shared/error_messages', resource: resource
       .field.has-text-left.has-text-weight-medium
         = f.label :email
-        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'football-myteam@example.com'
       .field.has-text-left.has-text-weight-medium
         = f.label :password
         - if @minimum_password_length

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,18 +1,19 @@
-.container.mx-auto.pt-5
-  h2.is-size-2.is-size-4-mobile.has-text-weight-semibold.has-text-centered
-    | ログイン
-  = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-    .field.has-text-left.has-text-weight-medium
-      = f.label :email
-      = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
-    .field.has-text-left.has-text-weight-medium
-      = f.label :password
-      = f.password_field :password, autocomplete: 'current-password', class: 'input'
-    - if devise_mapping.rememberable?
-      .field.has-text-weight-medium.has-text-right
-        = f.check_box :remember_me
-        = f.label :remember_me
-      .actions.has-text-centered
-        = f.submit t('.log_in'), class: 'color-button button is-rounded is-medium has-text-white mt-5'
-  .has-text-right.has-text-weight-medium.mt-3
-    = render 'devise/shared/links'
+.container
+  .section
+    h2.is-size-2.is-size-4-mobile.has-text-weight-semibold.has-text-centered
+      | ログイン
+    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      .field.has-text-left.has-text-weight-medium
+        = f.label :email
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
+      .field.has-text-left.has-text-weight-medium
+        = f.label :password
+        = f.password_field :password, autocomplete: 'current-password', class: 'input'
+      - if devise_mapping.rememberable?
+        .field.has-text-weight-medium.has-text-right
+          = f.check_box :remember_me
+          = f.label :remember_me
+        .actions.has-text-centered
+          = f.submit t('.log_in'), class: 'color-button button is-rounded is-medium has-text-white mt-5'
+    .has-text-right.has-text-weight-medium.mt-3
+      = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -5,7 +5,7 @@
     = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
       .field.has-text-left.has-text-weight-medium
         = f.label :email
-        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'football-myteam@example.com'
       .field.has-text-left.has-text-weight-medium
         = f.label :password
         = f.password_field :password, autocomplete: 'current-password', class: 'input'


### PR DESCRIPTION
## 対応した issue
#231 
## 対応内容・対応背景・妥協点
ユーザー認証画面のレイアウトが崩れていたので修正
## やったこと
- スマホサイズのときにマージンが入るようにした
- メールアドレス入力欄にプレースホルダーを入れた
- デフォルトのデザインになっていたパスワードリセットページのレイアウトを修正した

## UI before / after

### アカウント作成
#### before
<img width="269" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185512800-12630834-6202-45c9-a649-44f0f5db27ac.png">

#### after
<img width="282" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185512859-054dc09e-f2a6-4af1-8908-63c383614521.png">

### ログイン
#### before
<img width="347" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185512838-72660752-0738-4861-a28b-7ea03f7545fa.png">

#### after
<img width="281" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185512997-bacfb4b6-9377-48cd-bcf6-5589576d17eb.png">

### パスワードリセット
#### before
<img width="322" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185513010-ffc6ca22-af72-4aa4-85e4-a4b516454f5a.png">

#### after
<img width="282" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/185513022-2da8938d-5407-471b-940b-ea5d3fbdc8f2.png">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
