### PR TITLE
リダイレクト先を修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,13 @@
 
 class HomeController < ApplicationController
   def index
-    redirect_to '/schedules' if current_user
+    if current_user && current_user.favorite.present?
+      redirect_to '/schedules'
+    elsif current_user
+      redirect_to '/leagues'
+    else
+      root_path
+    end
   end
 
   def privacy_policy; end


### PR DESCRIPTION
## 対応した issue
#199 
## 対応内容・対応背景・妥協点
twitter認証でアカウント登録、またはアカウントを作成したがチームを登録していないユーザーがメインページに飛んでしまっていた。チームが登録できていないためローディングが常に表示されているだけの状態になっていた。

## やったこと
- ログインしていてチームを登録できている場合は`/schedules`にリダイレクト
- ログインしているがチームを登録できていない場合は`/leagues`にリダイレクト
- ログインできていない場合は`root_path`にリダイレクト

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
