### PR TITLE
ヘッダーの表記を変更した

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,10 +26,10 @@ html
             span aria-hidden="true"
               |
         #targetMenu.navbar-menu.has-background-main
-          .navbar-start
+          .navbar-start.mx-auto
             - if user_signed_in?
-                = link_to 'チームを変更する', '/leagues', class: 'burger-menu-item navbar-item has-text-white'
-                = link_to 'プロフィール変更', edit_user_registration_path, class: 'burger-menu-item navbar-item has-text-white'
+                = link_to 'チームを変更', '/leagues', class: 'burger-menu-item navbar-item has-text-white has-text-weight-medium'
+                = link_to 'プロフィール変更', edit_user_registration_path, class: 'burger-menu-item navbar-item has-text-white has-text-white has-text-weight-medium'
           .navbar-end
             - if user_signed_in?
                 = link_to 'Logout', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item button'


### PR DESCRIPTION
## 対応した issue
#238 
## 対応内容・対応背景・妥協点
ロゴとメニューが隣り合っていたので、それぞれの違いが分かりにくかった
## やったこと
- ヘッダーメニューを中央に移動させた
## UI before / after
### before
<img width="1249" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/186288512-e0c87482-f0d6-4e3f-aea9-4b28d44baa72.png">

### after
<img width="1429" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/186288496-f491d841-600c-4e6a-a2d3-80f8ca5eef26.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
