### PR TITLE
Feature/omniauth login button

### DIFF
--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -17,7 +17,7 @@
       .actions.has-text-centered
         = f.submit t('.sign_up'), class: 'color-button button is-rounded is-medium has-text-white'
     .twitter-login-button.has-text-centered
-      .is-size-3
+      .p.has-text-centered.is-size-3.has-text-grey-light
         | or
       .button.is-rounded.twitter-color.has-text-white
         .i.fa-brands.fa-twitter.fa-2x.m-2

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -5,10 +5,10 @@
     = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
       .field.has-text-left.has-text-weight-medium
         = f.label :email
-        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'football-myteam@example.com'
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'E-mail'
       .field.has-text-left.has-text-weight-medium
         = f.label :password
-        = f.password_field :password, autocomplete: 'current-password', class: 'input'
+        = f.password_field :password, autocomplete: 'current-password', class: 'input', placeholder: 'Password'
       - if devise_mapping.rememberable?
         .field.has-text-weight-medium.has-text-right
           = f.check_box :remember_me

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -15,5 +15,10 @@
           = f.label :remember_me
         .actions.has-text-centered
           = f.submit t('.log_in'), class: 'color-button button is-rounded is-medium has-text-white mt-5'
-    .has-text-right.has-text-weight-medium.mt-3
-      = render 'devise/shared/links'
+      .p.has-text-centered.is-size-3.has-text-grey-light
+        | OR
+      .twitter-login-button.has-text-centered.mt-3
+        .button.is-rounded.twitter-color.has-text-white
+          .i.fa-brands.fa-twitter.fa-2x.m-2
+          - resource_class.omniauth_providers.each do |provider|
+            = link_to 'Twitterでログインする', omniauth_authorize_path(resource_name, provider), method: :post, class: 'has-text-white'


### PR DESCRIPTION
## 対応した issue
#243 
## 対応内容・対応背景・妥協点
- Omniauthを使ってのログインを設置していなかった
- ログイン画面のパスワードの欄にプレースホルダーを用意していなかった
- deviseとOmniauthの境にあるorの色が重かった
## やったこと
- Twitterでログインできるようにした
- プレースホルダーを追加した
- orの文字色を変更した

## UI before / after
### ログイン画面
#### before
<img width="1436" alt="スクリーンショット 2022-08-28 20 12 47" src="https://user-images.githubusercontent.com/62058863/187071228-50093f23-8019-4e6b-b7e0-9d9808d6f712.png">

#### after
<img width="1437" alt="スクリーンショット 2022-08-28 20 13 03" src="https://user-images.githubusercontent.com/62058863/187071238-75bdd837-9622-4073-8eb1-c42df4d49936.png">

### アカウント作成画面
#### before
<img width="1237" alt="スクリーンショット 2022-08-28 20 14 41" src="https://user-images.githubusercontent.com/62058863/187071288-1f951b8b-8044-4db4-85db-b26288be617d.png">

#### after
<img width="1231" alt="スクリーンショット 2022-08-28 20 14 54" src="https://user-images.githubusercontent.com/62058863/187071294-5e911129-b791-4523-bd3e-b094adeea832.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
