### PR TITLE
22-23用にデータを入れ替えた

### DIFF
--- a/db/migrate/20220829075031_add_code_to_teams.rb
+++ b/db/migrate/20220829075031_add_code_to_teams.rb
@@ -1,0 +1,5 @@
+class AddCodeToTeams < ActiveRecord::Migration[6.1]
+  def change
+    add_column :teams, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_22_070413) do
+ActiveRecord::Schema.define(version: 2022_08_29_075031) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2022_08_22_070413) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "stadium"
     t.integer "last_season_rank"
+    t.string "code"
     t.index ["api_id"], name: "index_teams_on_api_id", unique: true
     t.index ["league_id"], name: "index_teams_on_league_id"
     t.index ["logo"], name: "index_teams_on_logo", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ Team.create(
   [
     {
       "id": 1,
-      "name": 'Manchester United',
+      "name": 'Man United',
       "logo": 'https://media.api-sports.io/football/teams/33.png',
       "api_id": 33,
       "league_id": 1,
@@ -185,7 +185,7 @@ Team.create(
     },
     {
       "id": 14,
-      "name": 'Manchester City',
+      "name": 'Man City',
       "logo": 'https://media.api-sports.io/football/teams/50.png',
       "api_id": 50,
       "league_id": 1,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,6 +34,7 @@ Team.create(
     {
       "id": 1,
       "name": 'Man United',
+      "code": 'MUN',
       "logo": 'https://media.api-sports.io/football/teams/33.png',
       "api_id": 33,
       "league_id": 1,
@@ -44,6 +45,7 @@ Team.create(
     {
       "id": 2,
       "name": 'Newcastle',
+      "code": 'NEW',
       "logo": 'https://media.api-sports.io/football/teams/34.png',
       "api_id": 34,
       "league_id": 1,
@@ -65,6 +67,7 @@ Team.create(
     {
       "id": 79,
       "name": 'Bournemouth',
+      "code": 'BOU',
       "logo": 'https://media.api-sports.io/football/teams/35.png',
       "api_id": 35,
       "league_id": 1,
@@ -75,6 +78,7 @@ Team.create(
     {
       "id": 80,
       "name": 'Fulham',
+      "code": 'FUL',
       "logo": 'https://media.api-sports.io/football/teams/36.png',
       "api_id": 36,
       "league_id": 1,
@@ -85,6 +89,7 @@ Team.create(
     {
       "id": 4,
       "name": 'Wolves',
+      "code": 'WOL',
       "logo": 'https://media.api-sports.io/football/teams/39.png',
       "api_id": 39,
       "league_id": 1,
@@ -95,6 +100,7 @@ Team.create(
     {
       "id": 5,
       "name": 'Liverpool',
+      "code": 'LIV',
       "logo": 'https://media.api-sports.io/football/teams/40.png',
       "api_id": 40,
       "league_id": 1,
@@ -105,6 +111,7 @@ Team.create(
     {
       "id": 6,
       "name": 'Southampton',
+      "code": 'SOU',
       "logo": 'https://media.api-sports.io/football/teams/41.png',
       "api_id": 41,
       "league_id": 1,
@@ -115,6 +122,7 @@ Team.create(
     {
       "id": 7,
       "name": 'Arsenal',
+      "code": 'ARS',
       "logo": 'https://media.api-sports.io/football/teams/42.png',
       "api_id": 42,
       "league_id": 1,
@@ -136,6 +144,7 @@ Team.create(
     {
       "id": 9,
       "name": 'Everton',
+      "code": 'EVE',
       "logo": 'https://media.api-sports.io/football/teams/45.png',
       "api_id": 45,
       "league_id": 1,
@@ -146,6 +155,7 @@ Team.create(
     {
       "id": 10,
       "name": 'Leicester',
+      "code": 'LEI',
       "logo": 'https://media.api-sports.io/football/teams/46.png',
       "api_id": 46,
       "league_id": 1,
@@ -156,6 +166,7 @@ Team.create(
     {
       "id": 11,
       "name": 'Tottenham',
+      "code": 'TOT',
       "logo": 'https://media.api-sports.io/football/teams/47.png',
       "api_id": 47,
       "league_id": 1,
@@ -166,6 +177,7 @@ Team.create(
     {
       "id": 12,
       "name": 'West Ham',
+      "code": 'WES',
       "logo": 'https://media.api-sports.io/football/teams/48.png',
       "api_id": 48,
       "league_id": 1,
@@ -176,6 +188,7 @@ Team.create(
     {
       "id": 13,
       "name": 'Chelsea',
+      "code": 'CHE',
       "logo": 'https://media.api-sports.io/football/teams/49.png',
       "api_id": 49,
       "league_id": 1,
@@ -186,6 +199,7 @@ Team.create(
     {
       "id": 14,
       "name": 'Man City',
+      "code": 'MAC',
       "logo": 'https://media.api-sports.io/football/teams/50.png',
       "api_id": 50,
       "league_id": 1,
@@ -196,6 +210,7 @@ Team.create(
     {
       "id": 15,
       "name": 'Brighton',
+      "code": 'BRI',
       "logo": 'https://media.api-sports.io/football/teams/51.png',
       "api_id": 51,
       "league_id": 1,
@@ -206,6 +221,7 @@ Team.create(
     {
       "id": 16,
       "name": 'Crystal Palace',
+      "code": 'CRY',
       "logo": 'https://media.api-sports.io/football/teams/52.png',
       "api_id": 52,
       "league_id": 1,
@@ -216,6 +232,7 @@ Team.create(
     {
       "id": 17,
       "name": 'Brentford',
+      "code": 'BRE',
       "logo": 'https://media.api-sports.io/football/teams/55.png',
       "api_id": 55,
       "league_id": 1,
@@ -226,6 +243,7 @@ Team.create(
     {
       "id": 18,
       "name": 'Leeds',
+      "code": 'LEE',
       "logo": 'https://media.api-sports.io/football/teams/63.png',
       "api_id": 63,
       "league_id": 1,
@@ -236,6 +254,7 @@ Team.create(
     {
       "id": 81,
       "name": 'Nottm Forest',
+      "code": 'NOT',
       "logo": 'https://media.api-sports.io/football/teams/65.png',
       "api_id": 65,
       "league_id": 1,
@@ -246,6 +265,7 @@ Team.create(
     {
       "id": 19,
       "name": 'Aston Villa',
+      "code": 'AST',
       "logo": 'https://media.api-sports.io/football/teams/66.png',
       "api_id": 66,
       "league_id": 1,
@@ -267,6 +287,7 @@ Team.create(
     {
       "id": 21,
       "name": 'Lazio',
+      "code": 'LAZ',
       "logo": 'https://media.api-sports.io/football/teams/487.png',
       "api_id": 487,
       "league_id": 2,
@@ -277,6 +298,7 @@ Team.create(
     {
       "id": 22,
       "name": 'Sassuolo',
+      "code": 'SAS',
       "logo": 'https://media.api-sports.io/football/teams/488.png',
       "api_id": 488,
       "league_id": 2,
@@ -287,6 +309,7 @@ Team.create(
     {
       "id": 23,
       "name": 'AC Milan',
+      "code": 'MIL',
       "logo": 'https://media.api-sports.io/football/teams/489.png',
       "api_id": 489,
       "league_id": 2,
@@ -308,6 +331,7 @@ Team.create(
     {
       "id": 25,
       "name": 'Napoli',
+      "code": 'NAP',
       "logo": 'https://media.api-sports.io/football/teams/492.png',
       "api_id": 492,
       "league_id": 2,
@@ -318,6 +342,7 @@ Team.create(
     {
       "id": 26,
       "name": 'Udinese',
+      "code": 'UDI',
       "logo": 'https://media.api-sports.io/football/teams/494.png',
       "api_id": 494,
       "league_id": 2,
@@ -339,6 +364,7 @@ Team.create(
     {
       "id": 28,
       "name": 'Juventus',
+      "code": 'JUV',
       "logo": 'https://media.api-sports.io/football/teams/496.png',
       "api_id": 496,
       "league_id": 2,
@@ -349,6 +375,7 @@ Team.create(
     {
       "id": 29,
       "name": 'AS Roma',
+      "code": 'ROM',
       "logo": 'https://media.api-sports.io/football/teams/497.png',
       "api_id": 497,
       "league_id": 2,
@@ -359,6 +386,7 @@ Team.create(
     {
       "id": 30,
       "name": 'Sampdoria',
+      "cide": 'SAM',
       "logo": 'https://media.api-sports.io/football/teams/498.png',
       "api_id": 498,
       "league_id": 2,
@@ -369,6 +397,7 @@ Team.create(
     {
       "id": 31,
       "name": 'Atalanta',
+      "code": 'ATA',
       "logo": 'https://media.api-sports.io/football/teams/499.png',
       "api_id": 499,
       "league_id": 2,
@@ -379,6 +408,7 @@ Team.create(
     {
       "id": 32,
       "name": 'Bologna',
+      "code": 'BOL',
       "logo": 'https://media.api-sports.io/football/teams/500.png',
       "api_id": 500,
       "league_id": 2,
@@ -389,6 +419,7 @@ Team.create(
     {
       "id": 33,
       "name": 'Fiorentina',
+      "code": 'FIO',
       "logo": 'https://media.api-sports.io/football/teams/502.png',
       "api_id": 502,
       "league_id": 2,
@@ -399,6 +430,7 @@ Team.create(
     {
       "id": 34,
       "name": 'Torino',
+      "code": 'TOR',
       "logo": 'https://media.api-sports.io/football/teams/503.png',
       "api_id": 503,
       "league_id": 2,
@@ -409,6 +441,7 @@ Team.create(
     {
       "id": 35,
       "name": 'Verona',
+      "code": 'VER',
       "logo": 'https://media.api-sports.io/football/teams/504.png',
       "api_id": 504,
       "league_id": 2,
@@ -419,6 +452,7 @@ Team.create(
     {
       "id": 36,
       "name": 'Inter',
+      "code": 'INT',
       "logo": 'https://media.api-sports.io/football/teams/505.png',
       "api_id": 505,
       "league_id": 2,
@@ -429,6 +463,7 @@ Team.create(
     {
       "id": 37,
       "name": 'Empoli',
+      "code": 'EMP',
       "logo": 'https://media.api-sports.io/football/teams/511.png',
       "api_id": 511,
       "league_id": 2,
@@ -439,6 +474,7 @@ Team.create(
     {
       "id": 38,
       "name": 'Salernitana',
+      "code": 'SAL',
       "logo": 'https://media.api-sports.io/football/teams/514.png',
       "api_id": 514,
       "league_id": 2,
@@ -449,6 +485,7 @@ Team.create(
     {
       "id": 39,
       "name": 'Spezia',
+      "code": 'SPE',
       "logo": 'https://media.api-sports.io/football/teams/515.png',
       "api_id": 515,
       "league_id": 2,
@@ -470,6 +507,7 @@ Team.create(
     {
       "id": 82,
       "name": 'Cremonese',
+      "code": 'CRE',
       "logo": 'https://media.api-sports.io/football/teams/520.png',
       "api_id": 520,
       "league_id": 2,
@@ -480,6 +518,7 @@ Team.create(
     {
       "id": 83,
       "name": 'Lecce',
+      "code": 'LEC',
       "logo": 'https://media.api-sports.io/football/teams/867.png',
       "api_id": 867,
       "league_id": 2,
@@ -490,6 +529,7 @@ Team.create(
     {
       "id": 84,
       "name": 'Monza',
+      "code": 'MON',
       "logo": 'https://media.api-sports.io/football/teams/1579.png',
       "api_id": 1579,
       "league_id": 2,
@@ -500,6 +540,7 @@ Team.create(
     {
       "id": 41,
       "name": 'Barcelona',
+      "code": 'BAR',
       "logo": 'https://media.api-sports.io/football/teams/529.png',
       "api_id": 529,
       "league_id": 3,
@@ -510,6 +551,7 @@ Team.create(
     {
       "id": 42,
       "name": 'Atletico Madrid',
+      "code": 'MAD',
       "logo": 'https://media.api-sports.io/football/teams/530.png',
       "api_id": 530,
       "league_id": 3,
@@ -520,6 +562,7 @@ Team.create(
     {
       "id": 43,
       "name": 'Athletic Club',
+      "code": 'BIL',
       "logo": 'https://media.api-sports.io/football/teams/531.png',
       "api_id": 531,
       "league_id": 3,
@@ -530,6 +573,7 @@ Team.create(
     {
       "id": 44,
       "name": 'Valencia',
+      "code": 'VAL',
       "logo": 'https://media.api-sports.io/football/teams/532.png',
       "api_id": 532,
       "league_id": 3,
@@ -540,6 +584,7 @@ Team.create(
     {
       "id": 45,
       "name": 'Villarreal',
+      "code": 'VIL',
       "logo": 'https://media.api-sports.io/football/teams/533.png',
       "api_id": 533,
       "league_id": 3,
@@ -550,6 +595,7 @@ Team.create(
     {
       "id": 46,
       "name": 'Sevilla',
+      "code": 'SEV',
       "logo": 'https://media.api-sports.io/football/teams/536.png',
       "api_id": 536,
       "league_id": 3,
@@ -560,6 +606,7 @@ Team.create(
     {
       "id": 47,
       "name": 'Celta Vigo',
+      "code": 'CEL',
       "logo": 'https://media.api-sports.io/football/teams/538.png',
       "api_id": 538,
       "league_id": 3,
@@ -581,6 +628,7 @@ Team.create(
     {
       "id": 49,
       "name": 'Espanyol',
+      "code": 'ESP',
       "logo": 'https://media.api-sports.io/football/teams/540.png',
       "api_id": 540,
       "league_id": 3,
@@ -591,6 +639,7 @@ Team.create(
     {
       "id": 50,
       "name": 'Real Madrid',
+      "code": 'REA',
       "logo": 'https://media.api-sports.io/football/teams/541.png',
       "api_id": 541,
       "league_id": 3,
@@ -612,6 +661,7 @@ Team.create(
     {
       "id": 52,
       "name": 'Real Betis',
+      "code": 'BET',
       "logo": 'https://media.api-sports.io/football/teams/543.png',
       "api_id": 543,
       "league_id": 3,
@@ -622,6 +672,7 @@ Team.create(
     {
       "id": 53,
       "name": 'Getafe',
+      "code": 'GET',
       "logo": 'https://media.api-sports.io/football/teams/546.png',
       "api_id": 546,
       "league_id": 3,
@@ -632,6 +683,7 @@ Team.create(
     {
       "id": 89,
       "name": 'Girona',
+      "code": 'GIR',
       "logo": 'https://media.api-sports.io/football/teams/547.png',
       "api_id": 547,
       "league_id": 3,
@@ -642,6 +694,7 @@ Team.create(
     {
       "id": 54,
       "name": 'Real Sociedad',
+      "code": 'RSO',
       "logo": 'https://media.api-sports.io/football/teams/548.png',
       "api_id": 548,
       "league_id": 3,
@@ -652,6 +705,7 @@ Team.create(
     {
       "id": 85,
       "name": 'Valladolid',
+      "code": 'VAL',
       "logo": 'https://media.api-sports.io/football/teams/720.png',
       "api_id": 720,
       "league_id": 3,
@@ -662,6 +716,7 @@ Team.create(
     {
       "id": 86,
       "name": 'Almeria',
+      "code": 'ALM',
       "logo": 'https://media.api-sports.io/football/teams/723.png',
       "api_id": 723,
       "league_id": 3,
@@ -683,6 +738,7 @@ Team.create(
     {
       "id": 56,
       "name": 'Cadiz',
+      "code": 'CAD',
       "logo": 'https://media.api-sports.io/football/teams/724.png',
       "api_id": 724,
       "league_id": 3,
@@ -693,6 +749,7 @@ Team.create(
     {
       "id": 57,
       "name": 'Osasuna',
+      "code": 'OSA',
       "logo": 'https://media.api-sports.io/football/teams/727.png',
       "api_id": 727,
       "league_id": 3,
@@ -703,6 +760,7 @@ Team.create(
     {
       "id": 58,
       "name": 'Rayo Vallecano',
+      "code": 'RAY',
       "logo": 'https://media.api-sports.io/football/teams/728.png',
       "api_id": 728,
       "league_id": 3,
@@ -713,6 +771,7 @@ Team.create(
     {
       "id": 59,
       "name": 'Elche',
+      "code": 'ELC',
       "logo": 'https://media.api-sports.io/football/teams/797.png',
       "api_id": 797,
       "league_id": 3,
@@ -723,6 +782,7 @@ Team.create(
     {
       "id": 60,
       "name": 'Mallorca',
+      "code": 'MAL',
       "logo": 'https://media.api-sports.io/football/teams/798.png',
       "api_id": 798,
       "league_id": 3,
@@ -733,6 +793,7 @@ Team.create(
     {
       "id": 61,
       "name": 'Bayern Munich',
+      "code": 'BAY',
       "logo": 'https://media.api-sports.io/football/teams/157.png',
       "api_id": 157,
       "league_id": 4,
@@ -743,6 +804,7 @@ Team.create(
     {
       "id": 62,
       "name": 'Hertha Berlin',
+      "code": 'HER',
       "logo": 'https://media.api-sports.io/football/teams/159.png',
       "api_id": 159,
       "league_id": 4,
@@ -753,6 +815,7 @@ Team.create(
     {
       "id": 63,
       "name": 'SC Freiburg',
+      "code": 'FRE',
       "logo": 'https://media.api-sports.io/football/teams/160.png',
       "api_id": 160,
       "league_id": 4,
@@ -763,6 +826,7 @@ Team.create(
     {
       "id": 64,
       "name": 'VfL Wolfsburg',
+      "code": 'WOL',
       "logo": 'https://media.api-sports.io/football/teams/161.png',
       "api_id": 161,
       "league_id": 4,
@@ -773,6 +837,7 @@ Team.create(
     {
       "id": 87,
       "name": 'Werder Bremen',
+      "code": 'WER',
       "logo": 'https://media.api-sports.io/football/teams/162.png',
       "api_id": 162,
       "league_id": 4,
@@ -784,6 +849,7 @@ Team.create(
     {
       "id": 65,
       "name": 'Borussia Monchengladbach',
+      "code": 'MOE',
       "logo": 'https://media.api-sports.io/football/teams/163.png',
       "api_id": 163,
       "league_id": 4,
@@ -794,6 +860,7 @@ Team.create(
     {
       "id": 66,
       "name": 'FSV Mainz 05',
+      "code": 'MAI',
       "logo": 'https://media.api-sports.io/football/teams/164.png',
       "api_id": 164,
       "league_id": 4,
@@ -804,6 +871,7 @@ Team.create(
     {
       "id": 67,
       "name": 'Borussia Dortmund',
+      "code": 'DOR',
       "logo": 'https://media.api-sports.io/football/teams/165.png',
       "api_id": 165,
       "league_id": 4,
@@ -814,6 +882,7 @@ Team.create(
     {
       "id": 68,
       "name": '1899 Hoffenheim',
+      "code": 'HOF',
       "logo": 'https://media.api-sports.io/football/teams/167.png',
       "api_id": 167,
       "league_id": 4,
@@ -824,6 +893,7 @@ Team.create(
     {
       "id": 69,
       "name": 'Bayer Leverkusen',
+      "code": 'BAY',
       "logo": 'https://media.api-sports.io/football/teams/168.png',
       "api_id": 168,
       "league_id": 4,
@@ -834,6 +904,7 @@ Team.create(
     {
       "id": 70,
       "name": 'Eintracht Frankfurt',
+      "code": 'EIN',
       "logo": 'https://media.api-sports.io/football/teams/169.png',
       "api_id": 169,
       "league_id": 4,
@@ -844,6 +915,7 @@ Team.create(
     {
       "id": 71,
       "name": 'FC Augsburg',
+      "code": 'AUG',
       "logo": 'https://media.api-sports.io/football/teams/170.png',
       "api_id": 170,
       "league_id": 4,
@@ -854,6 +926,7 @@ Team.create(
     {
       "id": 72,
       "name": 'VfB Stuttgart',
+      "code": 'STU',
       "logo": 'https://media.api-sports.io/football/teams/172.png',
       "api_id": 172,
       "league_id": 4,
@@ -864,6 +937,7 @@ Team.create(
     {
       "id": 73,
       "name": 'RB Leipzig',
+      "code": 'LEI',
       "logo": 'https://media.api-sports.io/football/teams/173.png',
       "api_id": 173,
       "league_id": 4,
@@ -874,6 +948,7 @@ Team.create(
     {
       "id": 88,
       "name": 'FC Schalke 04',
+      "code": 'SCH',
       "logo": 'https://media.api-sports.io/football/teams/174.png',
       "api_id": 174,
       "league_id": 4,
@@ -884,6 +959,7 @@ Team.create(
     {
       "id": 74,
       "name": 'VfL BOCHUM',
+      "code": 'BOC',
       "logo": 'https://media.api-sports.io/football/teams/176.png',
       "api_id": 176,
       "league_id": 4,
@@ -905,6 +981,7 @@ Team.create(
     {
       "id": 76,
       "name": 'Union Berlin',
+      "code": 'UNI',
       "logo": 'https://media.api-sports.io/football/teams/182.png',
       "api_id": 182,
       "league_id": 4,
@@ -926,6 +1003,7 @@ Team.create(
     {
       "id": 78,
       "name": 'FC Koln',
+      "code": 'KOL',
       "logo": 'https://media.api-sports.io/football/teams/192.png',
       "api_id": 192,
       "league_id": 4,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,7 +39,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Manchester',
       "stadium": 'Old Trafford',
-      "last_season_rank": 2
+      "last_season_rank": 6
     },
     {
       "id": 2,
@@ -49,7 +49,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Newcastle upon Tyne',
       "stadium": "St. James' Park",
-      "last_season_rank": 12
+      "last_season_rank": 11
     },
     # 2021-2022降格
     # {
@@ -90,7 +90,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Wolverhampton, West Midlands',
       "stadium": 'Molineux Stadium',
-      "last_season_rank": 13
+      "last_season_rank": 10
     },
     {
       "id": 5,
@@ -100,7 +100,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Liverpool',
       "stadium": 'Anfield',
-      "last_season_rank": 3
+      "last_season_rank": 2
     },
     {
       "id": 6,
@@ -120,7 +120,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Emirates Stadium',
-      "last_season_rank": 8
+      "last_season_rank": 5
     },
     # 2021-2022降格
     # {
@@ -141,7 +141,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Liverpool',
       "stadium": 'Goodison Park',
-      "last_season_rank": 10
+      "last_season_rank": 16
     },
     {
       "id": 10,
@@ -151,7 +151,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Leicester, Leicestershire',
       "stadium": 'King Power Stadium',
-      "last_season_rank": 5
+      "last_season_rank": 8
     },
     {
       "id": 11,
@@ -161,7 +161,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Tottenham Hotspur Stadium',
-      "last_season_rank": 7
+      "last_season_rank": 4
     },
     {
       "id": 12,
@@ -171,7 +171,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'London Stadium',
-      "last_season_rank": 6
+      "last_season_rank": 7
     },
     {
       "id": 13,
@@ -181,7 +181,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Stamford Bridge',
-      "last_season_rank": 4
+      "last_season_rank": 3
     },
     {
       "id": 14,
@@ -201,7 +201,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Falmer, East Sussex',
       "stadium": 'The American Express Community Stadium',
-      "last_season_rank": 16
+      "last_season_rank": 9
     },
     {
       "id": 16,
@@ -211,7 +211,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Selhurst Park',
-      "last_season_rank": 14
+      "last_season_rank": 12
     },
     {
       "id": 17,
@@ -221,7 +221,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Brentford Community Stadium',
-      "last_season_rank": ''
+      "last_season_rank": 13
     },
     {
       "id": 18,
@@ -231,11 +231,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Leeds',
       "stadium": 'Elland Road',
-      "last_season_rank": 9
+      "last_season_rank": 17
     },
     {
       "id": 81,
-      "name": 'Nottingham Forest',
+      "name": 'Nottm Forest',
       "logo": 'https://media.api-sports.io/football/teams/65.png',
       "api_id": 65,
       "league_id": 1,
@@ -251,7 +251,7 @@ Team.create(
       "league_id": 1,
       "home_city": 'Birmingham',
       "stadium": 'Villa Park',
-      "last_season_rank": 11
+      "last_season_rank": 14
     },
     # 2021-2022降格
     # {
@@ -272,7 +272,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Roma',
       "stadium": 'Stadio Olimpico',
-      "last_season_rank": 6
+      "last_season_rank": 5
     },
     {
       "id": 22,
@@ -282,7 +282,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Reggio nell&apos;Emilia',
       "stadium": 'MAPEI Stadium - Città del Tricolore',
-      "last_season_rank": 8
+      "last_season_rank": 11
     },
     {
       "id": 23,
@@ -292,7 +292,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Milano',
       "stadium": 'Stadio Giuseppe Meazza',
-      "last_season_rank": 2
+      "last_season_rank": 1
     },
     # 2021-2022降格
     # {
@@ -313,7 +313,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Napoli',
       "stadium": 'Stadio Diego Armando Maradona',
-      "last_season_rank": 5
+      "last_season_rank": 3
     },
     {
       "id": 26,
@@ -323,7 +323,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Udine',
       "stadium": 'Dacia Arena',
-      "last_season_rank": 14
+      "last_season_rank": 12
     },
     # 2021-2022降格
     # {
@@ -354,7 +354,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Roma',
       "stadium": 'Stadio Olimpico',
-      "last_season_rank": 7
+      "last_season_rank": 6
     },
     {
       "id": 30,
@@ -364,7 +364,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Genova',
       "stadium": 'Stadio Comunale Luigi Ferraris',
-      "last_season_rank": 9
+      "last_season_rank": 15
     },
     {
       "id": 31,
@@ -374,7 +374,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Bergamo',
       "stadium": 'Gewiss Stadium',
-      "last_season_rank": 3
+      "last_season_rank": 8
     },
     {
       "id": 32,
@@ -384,7 +384,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Bologna',
       "stadium": "Stadio Renato Dall'Ara",
-      "last_season_rank": 12
+      "last_season_rank": 13
     },
     {
       "id": 33,
@@ -394,7 +394,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Firenze',
       "stadium": 'Stadio Artemio Franchi',
-      "last_season_rank": 13
+      "last_season_rank": 7
     },
     {
       "id": 34,
@@ -404,7 +404,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Torino',
       "stadium": 'Stadio Olimpico Grande Torino',
-      "last_season_rank": 17
+      "last_season_rank": 10
     },
     {
       "id": 35,
@@ -414,7 +414,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Verona',
       "stadium": "Stadio Marc'Antonio Bentegodi",
-      "last_season_rank": 10
+      "last_season_rank": 9
     },
     {
       "id": 36,
@@ -424,7 +424,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Milano',
       "stadium": 'Stadio Giuseppe Meazza',
-      "last_season_rank": 1
+      "last_season_rank": 2
     },
     {
       "id": 37,
@@ -434,7 +434,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Empoli',
       "stadium": 'Stadio Carlo Castellani',
-      "last_season_rank": ''
+      "last_season_rank": 14
     },
     {
       "id": 38,
@@ -444,7 +444,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'Salerno',
       "stadium": 'Stadio Arechi',
-      "last_season_rank": ''
+      "last_season_rank": 17
     },
     {
       "id": 39,
@@ -454,7 +454,7 @@ Team.create(
       "league_id": 2,
       "home_city": 'La Spezia',
       "stadium": 'Stadio Alberto Picco',
-      "last_season_rank": 15
+      "last_season_rank": 16
     },
     # 2021-2022降格
     # {
@@ -505,7 +505,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Barcelona',
       "stadium": 'Camp Nou',
-      "last_season_rank": 3
+      "last_season_rank": 2
     },
     {
       "id": 42,
@@ -515,7 +515,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Madrid',
       "stadium": 'Estadio Wanda Metropolitano',
-      "last_season_rank": 1
+      "last_season_rank": 3
     },
     {
       "id": 43,
@@ -525,7 +525,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Bilbao',
       "stadium": 'San Mamés Barria',
-      "last_season_rank": 10
+      "last_season_rank": 8
     },
     {
       "id": 44,
@@ -535,7 +535,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Valencia',
       "stadium": 'Estadio de Mestalla',
-      "last_season_rank": 13
+      "last_season_rank": 9
     },
     {
       "id": 45,
@@ -555,7 +555,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Sevilla',
       "stadium": 'Estadio Ramón Sánchez Pizjuán',
-      "last_season_rank": 4
+      "last_season_rank": 11
     },
     {
       "id": 47,
@@ -586,7 +586,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Cornella de Llobregat',
       "stadium": 'RCDE Stadium',
-      "last_season_rank": 1
+      "last_season_rank": 14
     },
     {
       "id": 50,
@@ -596,7 +596,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Madrid',
       "stadium": 'Estadio Santiago Bernabéu',
-      "last_season_rank": 2
+      "last_season_rank": 1
     },
     # 2021-2022降格
     # {
@@ -617,7 +617,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Sevilla',
       "stadium": 'Estadio Benito Villamarín',
-      "last_season_rank": 6
+      "last_season_rank": 5
     },
     {
       "id": 53,
@@ -630,6 +630,16 @@ Team.create(
       "last_season_rank": 15
     },
     {
+      "id": 89,
+      "name": 'Girona',
+      "logo": 'https://media.api-sports.io/football/teams/547.png',
+      "api_id": 547,
+      "league_id": 3,
+      "home_city": 'Girona',
+      "stadium": 'Estadi Municipal de Montilivi',
+      "last_season_rank": ''
+    },
+    {
       "id": 54,
       "name": 'Real Sociedad',
       "logo": 'https://media.api-sports.io/football/teams/548.png',
@@ -637,7 +647,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Donostia-San Sebastián',
       "stadium": 'Reale Arena',
-      "last_season_rank": 5
+      "last_season_rank": 6
     },
     {
       "id": 85,
@@ -678,7 +688,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Cádiz',
       "stadium": 'Estadio Nuevo Mirandilla',
-      "last_season_rank": 12
+      "last_season_rank": 17
     },
     {
       "id": 57,
@@ -688,7 +698,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Iruñea',
       "stadium": 'Estadio El Sadar',
-      "last_season_rank": 11
+      "last_season_rank": 10
     },
     {
       "id": 58,
@@ -697,7 +707,8 @@ Team.create(
       "api_id": 728,
       "league_id": 3,
       "stadium": 'Estadio de Vallecas',
-      "home_city": 'Madrid'
+      "home_city": 'Madrid',
+      "last_season_rank": 12
     },
     {
       "id": 59,
@@ -707,7 +718,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Elche',
       "stadium": 'Estadio Manuel Martínez Valero',
-      "last_season_rank": 17
+      "last_season_rank": 13
     },
     {
       "id": 60,
@@ -717,7 +728,7 @@ Team.create(
       "league_id": 3,
       "home_city": 'Palma de Mallorca',
       "stadium": 'Visit Mallorca Estadi',
-      "last_season_rank": ''
+      "last_season_rank": 16
     },
     {
       "id": 61,
@@ -737,7 +748,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Berlin',
       "stadium": 'Olympiastadion Berlin',
-      "last_season_rank": 14
+      "last_season_rank": 16
     },
     {
       "id": 63,
@@ -747,7 +758,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Freiburg im Breisgau',
       "stadium": 'Europa-Park Stadion',
-      "last_season_rank": 10
+      "last_season_rank": 6
     },
     {
       "id": 64,
@@ -757,7 +768,7 @@ Team.create(
       "league_id": 4,
       "stadium": 'VOLKSWAGEN ARENA',
       "home_city": 'Wolfsburg',
-      "last_season_rank": 4
+      "last_season_rank": 12
     },
     {
       "id": 87,
@@ -778,7 +789,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Mönchengladbach',
       "stadium": 'Stadion im BORUSSIA-PARK',
-      "last_season_rank": 8
+      "last_season_rank": 10
     },
     {
       "id": 66,
@@ -788,7 +799,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Mainz',
       "stadium": 'MEWA ARENA',
-      "last_season_rank": 12
+      "last_season_rank": 8
     },
     {
       "id": 67,
@@ -798,7 +809,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Dortmund',
       "stadium": 'Signal-Iduna-Park',
-      "last_season_rank": 3
+      "last_season_rank": 2
     },
     {
       "id": 68,
@@ -808,7 +819,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Sinsheim',
       "stadium": 'PreZero Arena',
-      "last_season_rank": 11
+      "last_season_rank": 9
     },
     {
       "id": 69,
@@ -818,7 +829,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Leverkusen',
       "stadium": 'BayArena',
-      "last_season_rank": 6
+      "last_season_rank": 3
     },
     {
       "id": 70,
@@ -828,7 +839,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Frankfurt am Main',
       "stadium": 'Deutsche Bank Park',
-      "last_season_rank": 5
+      "last_season_rank": 11
     },
     {
       "id": 71,
@@ -838,7 +849,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Augsburg',
       "stadium": 'WWK Arena',
-      "last_season_rank": 13
+      "last_season_rank": 14
     },
     {
       "id": 72,
@@ -848,7 +859,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Stuttgart',
       "stadium": 'Mercedes-Benz-Arena',
-      "last_season_rank": 9
+      "last_season_rank": 15
     },
     {
       "id": 73,
@@ -858,7 +869,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Leipzig',
       "stadium": 'Red Bull Arena',
-      "last_season_rank": 2
+      "last_season_rank": 4
     },
     {
       "id": 88,
@@ -878,7 +889,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Bochum',
       "stadium": 'Vonovia Ruhrstadion',
-      "last_season_rank": ''
+      "last_season_rank": 13
     },
     # 2021-2022降格
     # {
@@ -899,7 +910,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Berlin',
       "stadium": 'Stadion An der Alten Försterei',
-      "last_season_rank": 7
+      "last_season_rank": 5
     },
     # 2021-2022降格
     # {
@@ -920,7 +931,7 @@ Team.create(
       "league_id": 4,
       "home_city": 'Köln',
       "stadium": 'RheinEnergieStadion',
-      "last_season_rank": 16
+      "last_season_rank": 7
     }
   ]
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ League.create(
 
 Team.create(
   [
-  # --------- Premier ---------------
+    # --------- Premier ---------------
     {
       "id": 1,
       "name": 'Man United',
@@ -729,14 +729,14 @@ Team.create(
     },
     # 2021-2022降格
     # {
-      # "id": 55,
-      # "name": 'Granada CF',
-      # "logo": 'https://media.api-sports.io/football/teams/715.png',
-      # "api_id": 715,
-      # "league_id": 3,
-      # "home_city": 'Granada',
-      # "stadium": 'Estadio Nuevo Los Cármenes',
-      # "last_season_rank": 9
+    # "id": 55,
+    # "name": 'Granada CF',
+    # "logo": 'https://media.api-sports.io/football/teams/715.png',
+    # "api_id": 715,
+    # "league_id": 3,
+    # "home_city": 'Granada',
+    # "stadium": 'Estadio Nuevo Los Cármenes',
+    # "last_season_rank": 9
     # },
     {
       "id": 56,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,6 +31,7 @@ League.create(
 
 Team.create(
   [
+  # --------- Premier ---------------
     {
       "id": 1,
       "name": 'Man United',
@@ -284,6 +285,7 @@ Team.create(
     #   "stadium": 'Carrow Road',
     #   "last_season_rank": ''
     # },
+    # --------- SelieA ---------------
     {
       "id": 21,
       "name": 'Lazio',
@@ -537,6 +539,7 @@ Team.create(
       "stadium": 'U-Power Stadium',
       "last_season_rank": ''
     },
+    # --------- LaLiga ---------------
     {
       "id": 41,
       "name": 'Barcelona',
@@ -790,6 +793,7 @@ Team.create(
       "stadium": 'Visit Mallorca Estadi',
       "last_season_rank": 16
     },
+    # --------- LaLiga ---------------
     {
       "id": 61,
       "name": 'Bayern Munich',
@@ -843,7 +847,6 @@ Team.create(
       "league_id": 4,
       "stadium": 'wohninvest WESERSTADION',
       "home_city": 'Bremen',
-
       "last_season_rank": ''
     },
     {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,14 +51,35 @@ Team.create(
       "stadium": "St. James' Park",
       "last_season_rank": 12
     },
+    # 2021-2022降格
+    # {
+    #   "id": 3,
+    #   "name": 'Watford',
+    #   "logo": 'https://media.api-sports.io/football/teams/38.png',
+    #   "api_id": 38,
+    #   "league_id": 1,
+    #   "home_city": 'Watford',
+    #   "stadium": 'Vicarage Road',
+    #   "last_season_rank": ''
+    # },
     {
-      "id": 3,
-      "name": 'Watford',
-      "logo": 'https://media.api-sports.io/football/teams/38.png',
-      "api_id": 38,
+      "id": 79,
+      "name": 'Bournemouth',
+      "logo": 'https://media.api-sports.io/football/teams/35.png',
+      "api_id": 35,
       "league_id": 1,
-      "home_city": 'Watford',
-      "stadium": 'Vicarage Road',
+      "home_city": 'Bournemouth',
+      "stadium": 'Vitality Stadium',
+      "last_season_rank": ''
+    },
+    {
+      "id": 80,
+      "name": 'Fulham',
+      "logo": 'https://media.api-sports.io/football/teams/36.png',
+      "api_id": 36,
+      "league_id": 1,
+      "home_city": 'London',
+      "stadium": 'Craven Cottage',
       "last_season_rank": ''
     },
     {
@@ -101,16 +122,17 @@ Team.create(
       "stadium": 'Emirates Stadium',
       "last_season_rank": 8
     },
-    {
-      "id": 8,
-      "name": 'Burnley',
-      "logo": 'https://media.api-sports.io/football/teams/44.png',
-      "api_id": 44,
-      "league_id": 1,
-      "home_city": 'Burnley',
-      "stadium": 'Turf Moor',
-      "last_season_rank": 17
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 8,
+    #   "name": 'Burnley',
+    #   "logo": 'https://media.api-sports.io/football/teams/44.png',
+    #   "api_id": 44,
+    #   "league_id": 1,
+    #   "home_city": 'Burnley',
+    #   "stadium": 'Turf Moor',
+    #   "last_season_rank": 17
+    # },
     {
       "id": 9,
       "name": 'Everton',
@@ -197,7 +219,7 @@ Team.create(
       "logo": 'https://media.api-sports.io/football/teams/55.png',
       "api_id": 55,
       "league_id": 1,
-      "home_city": 'Brentford, Middlesex',
+      "home_city": 'London',
       "stadium": 'Brentford Community Stadium',
       "last_season_rank": ''
     },
@@ -207,9 +229,19 @@ Team.create(
       "logo": 'https://media.api-sports.io/football/teams/63.png',
       "api_id": 63,
       "league_id": 1,
-      "home_city": 'Leeds, West Yorkshire',
+      "home_city": 'Leeds',
       "stadium": 'Elland Road',
       "last_season_rank": 9
+    },
+    {
+      "id": 81,
+      "name": 'Nottingham Forest',
+      "logo": 'https://media.api-sports.io/football/teams/65.png',
+      "api_id": 65,
+      "league_id": 1,
+      "home_city": 'Nottingham',
+      "stadium": 'The City Ground',
+      "last_season_rank": ''
     },
     {
       "id": 19,
@@ -221,16 +253,17 @@ Team.create(
       "stadium": 'Villa Park',
       "last_season_rank": 11
     },
-    {
-      "id": 20,
-      "name": 'Norwich',
-      "logo": 'https://media.api-sports.io/football/teams/71.png',
-      "api_id": 71,
-      "league_id": 1,
-      "home_city": 'Norwich, Norfolk',
-      "stadium": 'Carrow Road',
-      "last_season_rank": ''
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 20,
+    #   "name": 'Norwich',
+    #   "logo": 'https://media.api-sports.io/football/teams/71.png',
+    #   "api_id": 71,
+    #   "league_id": 1,
+    #   "home_city": 'Norwich, Norfolk',
+    #   "stadium": 'Carrow Road',
+    #   "last_season_rank": ''
+    # },
     {
       "id": 21,
       "name": 'Lazio',
@@ -261,16 +294,17 @@ Team.create(
       "stadium": 'Stadio Giuseppe Meazza',
       "last_season_rank": 2
     },
-    {
-      "id": 24,
-      "name": 'Cagliari',
-      "logo": 'https://media.api-sports.io/football/teams/490.png',
-      "api_id": 490,
-      "league_id": 2,
-      "home_city": 'Cagliari',
-      "stadium": 'Unipol Domus',
-      "last_season_rank": 16
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 24,
+    #   "name": 'Cagliari',
+    #   "logo": 'https://media.api-sports.io/football/teams/490.png',
+    #   "api_id": 490,
+    #   "league_id": 2,
+    #   "home_city": 'Cagliari',
+    #   "stadium": 'Unipol Domus',
+    #   "last_season_rank": 16
+    # },
     {
       "id": 25,
       "name": 'Napoli',
@@ -291,16 +325,17 @@ Team.create(
       "stadium": 'Dacia Arena',
       "last_season_rank": 14
     },
-    {
-      "id": 27,
-      "name": 'Genoa',
-      "logo": 'https://media.api-sports.io/football/teams/495.png',
-      "api_id": 495,
-      "league_id": 2,
-      "home_city": 'Genova',
-      "stadium": 'Stadio Comunale Luigi Ferraris',
-      "last_season_rank": 11
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 27,
+    #   "name": 'Genoa',
+    #   "logo": 'https://media.api-sports.io/football/teams/495.png',
+    #   "api_id": 495,
+    #   "league_id": 2,
+    #   "home_city": 'Genova',
+    #   "stadium": 'Stadio Comunale Luigi Ferraris',
+    #   "last_season_rank": 11
+    # },
     {
       "id": 28,
       "name": 'Juventus',
@@ -421,14 +456,45 @@ Team.create(
       "stadium": 'Stadio Alberto Picco',
       "last_season_rank": 15
     },
+    # 2021-2022降格
+    # {
+    #   "id": 40,
+    #   "name": 'Venezia',
+    #   "logo": 'https://media.api-sports.io/football/teams/517.png',
+    #   "api_id": 517,
+    #   "league_id": 2,
+    #   "home_city": 'Venezia',
+    #   "stadium": 'Stadio Pierluigi Penzo',
+    #   "last_season_rank": ''
+    # },
     {
-      "id": 40,
-      "name": 'Venezia',
-      "logo": 'https://media.api-sports.io/football/teams/517.png',
-      "api_id": 517,
+      "id": 82,
+      "name": 'Cremonese',
+      "logo": 'https://media.api-sports.io/football/teams/520.png',
+      "api_id": 520,
       "league_id": 2,
-      "home_city": 'Venezia',
-      "stadium": 'Stadio Pierluigi Penzo',
+      "home_city": 'Cremona',
+      "stadium": 'Stadio Giovanni Zini',
+      "last_season_rank": ''
+    },
+    {
+      "id": 83,
+      "name": 'Lecce',
+      "logo": 'https://media.api-sports.io/football/teams/867.png',
+      "api_id": 867,
+      "league_id": 2,
+      "home_city": 'Lecce',
+      "stadium": 'Stadio Comunale Via del Mare',
+      "last_season_rank": ''
+    },
+    {
+      "id": 84,
+      "name": 'Monza',
+      "logo": 'https://media.api-sports.io/football/teams/1579.png',
+      "api_id": 1579,
+      "league_id": 2,
+      "home_city": 'Monza',
+      "stadium": 'U-Power Stadium',
       "last_season_rank": ''
     },
     {
@@ -501,16 +567,17 @@ Team.create(
       "stadium": 'Abanca-Balaídos',
       "last_season_rank": 8
     },
-    {
-      "id": 48,
-      "name": 'Levante',
-      "logo": 'https://media.api-sports.io/football/teams/539.png',
-      "api_id": 539,
-      "league_id": 3,
-      "home_city": 'Valencia',
-      "stadium": 'Estadio Ciudad de Valencia',
-      "last_season_rank": 14
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 48,
+    #   "name": 'Levante',
+    #   "logo": 'https://media.api-sports.io/football/teams/539.png',
+    #   "api_id": 539,
+    #   "league_id": 3,
+    #   "home_city": 'Valencia',
+    #   "stadium": 'Estadio Ciudad de Valencia',
+    #   "last_season_rank": 14
+    # },
     {
       "id": 49,
       "name": 'Espanyol',
@@ -531,16 +598,17 @@ Team.create(
       "stadium": 'Estadio Santiago Bernabéu',
       "last_season_rank": 2
     },
-    {
-      "id": 51,
-      "name": 'Alaves',
-      "logo": 'https://media.api-sports.io/football/teams/542.png',
-      "api_id": 542,
-      "league_id": 3,
-      "home_city": 'Vitoria-Gasteiz',
-      "stadium": 'Estadio de Mendizorroza',
-      "last_season_rank": 16
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 51,
+    #   "name": 'Alaves',
+    #   "logo": 'https://media.api-sports.io/football/teams/542.png',
+    #   "api_id": 542,
+    #   "league_id": 3,
+    #   "home_city": 'Vitoria-Gasteiz',
+    #   "stadium": 'Estadio de Mendizorroza',
+    #   "last_season_rank": 16
+    # },
     {
       "id": 52,
       "name": 'Real Betis',
@@ -572,15 +640,36 @@ Team.create(
       "last_season_rank": 5
     },
     {
-      "id": 55,
-      "name": 'Granada CF',
-      "logo": 'https://media.api-sports.io/football/teams/715.png',
-      "api_id": 715,
+      "id": 85,
+      "name": 'Valladolid',
+      "logo": 'https://media.api-sports.io/football/teams/720.png',
+      "api_id": 720,
       "league_id": 3,
-      "home_city": 'Granada',
-      "stadium": 'Estadio Nuevo Los Cármenes',
-      "last_season_rank": 9
+      "home_city": 'Avenida del Mundial 82',
+      "stadium": 'Estadio Municipal José Zorrilla',
+      "last_season_rank": ''
     },
+    {
+      "id": 86,
+      "name": 'Almeria',
+      "logo": 'https://media.api-sports.io/football/teams/723.png',
+      "api_id": 723,
+      "league_id": 3,
+      "home_city": 'Calle de Belladona',
+      "stadium": 'Estadio de los Juegos Mediterráneos',
+      "last_season_rank": ''
+    },
+    # 2021-2022降格
+    # {
+      # "id": 55,
+      # "name": 'Granada CF',
+      # "logo": 'https://media.api-sports.io/football/teams/715.png',
+      # "api_id": 715,
+      # "league_id": 3,
+      # "home_city": 'Granada',
+      # "stadium": 'Estadio Nuevo Los Cármenes',
+      # "last_season_rank": 9
+    # },
     {
       "id": 56,
       "name": 'Cadiz',
@@ -668,8 +757,18 @@ Team.create(
       "league_id": 4,
       "stadium": 'VOLKSWAGEN ARENA',
       "home_city": 'Wolfsburg',
-
       "last_season_rank": 4
+    },
+    {
+      "id": 87,
+      "name": 'Werder Bremen',
+      "logo": 'https://media.api-sports.io/football/teams/162.png',
+      "api_id": 162,
+      "league_id": 4,
+      "stadium": 'wohninvest WESERSTADION',
+      "home_city": 'Bremen',
+
+      "last_season_rank": ''
     },
     {
       "id": 65,
@@ -762,6 +861,16 @@ Team.create(
       "last_season_rank": 2
     },
     {
+      "id": 88,
+      "name": 'FC Schalke 04',
+      "logo": 'https://media.api-sports.io/football/teams/174.png',
+      "api_id": 174,
+      "league_id": 4,
+      "home_city": 'Gelsenkirchen',
+      "stadium": 'VELTINS-Arena',
+      "last_season_rank": ''
+    },
+    {
       "id": 74,
       "name": 'VfL BOCHUM',
       "logo": 'https://media.api-sports.io/football/teams/176.png',
@@ -771,16 +880,17 @@ Team.create(
       "stadium": 'Vonovia Ruhrstadion',
       "last_season_rank": ''
     },
-    {
-      "id": 75,
-      "name": 'SpVgg Greuther Furth',
-      "logo": 'https://media.api-sports.io/football/teams/178.png',
-      "api_id": 178,
-      "league_id": 4,
-      "home_city": 'Fürth',
-      "stadium": 'Sportpark Ronhof Thomas Sommer',
-      "last_season_rank": ''
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 75,
+    #   "name": 'SpVgg Greuther Furth',
+    #   "logo": 'https://media.api-sports.io/football/teams/178.png',
+    #   "api_id": 178,
+    #   "league_id": 4,
+    #   "home_city": 'Fürth',
+    #   "stadium": 'Sportpark Ronhof Thomas Sommer',
+    #   "last_season_rank": ''
+    # },
     {
       "id": 76,
       "name": 'Union Berlin',
@@ -791,16 +901,17 @@ Team.create(
       "stadium": 'Stadion An der Alten Försterei',
       "last_season_rank": 7
     },
-    {
-      "id": 77,
-      "name": 'Arminia Bielefeld',
-      "logo": 'https://media.api-sports.io/football/teams/188.png',
-      "api_id": 188,
-      "league_id": 4,
-      "home_city": 'Bielefeld',
-      "stadium": 'SchücoArena',
-      "last_season_rank": 15
-    },
+    # 2021-2022降格
+    # {
+    #   "id": 77,
+    #   "name": 'Arminia Bielefeld',
+    #   "logo": 'https://media.api-sports.io/football/teams/188.png',
+    #   "api_id": 188,
+    #   "league_id": 4,
+    #   "home_city": 'Bielefeld',
+    #   "stadium": 'SchücoArena',
+    #   "last_season_rank": 15
+    # },
     {
       "id": 78,
       "name": 'FC Koln',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -388,7 +388,7 @@ Team.create(
     {
       "id": 30,
       "name": 'Sampdoria',
-      "cide": 'SAM',
+      "code": 'SAM',
       "logo": 'https://media.api-sports.io/football/teams/498.png',
       "api_id": 498,
       "league_id": 2,


### PR DESCRIPTION
## 対応した issue
#146 
## 対応内容・対応背景・妥協点
- seedに入っているデータが21-22用になっているので修正した
- レスポンシブのときにチーム名を表示するために省略名を追加した
## やったこと
- 降格チームをコメントアウト
- 昇格チームの情報を入力
- 省略名の追加

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
