### PR TITLE
試合情報の取得と更新の方法を変更した

### DIFF
--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -5,11 +5,7 @@ class API::MatchesController < ApplicationController
   before_action :api_request
 
   def index
-    favorite_team = current_user.favorite.team
-    competitors = current_user.competitor.map(&:team_id)
-    teams = competitors.unshift(favorite_team.id)
-    match = Match.all.order(:date).where(date: Time.zone.today..).where(team_id: teams)
-    @match = match
+    @match = Match.all.order(:date).where(date: Time.zone.today..).where(team_id: selected_team_ids)
   end
 
   def show
@@ -31,13 +27,21 @@ class API::MatchesController < ApplicationController
   end
 
   def api_request_url
-    api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
+    api_id = competitor_team_api_id.unshift(current_user.favorite.team.api_id)
     api_id.map do |i|
       URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}")
     end
   end
 
-  def competitor_teams
+  def selected_team_ids
+    competitor_team_id.unshift(current_user.favorite.team.id)
+  end
+
+  def competitor_team_api_id
     SelectTeam.competitor_team_api_id(current_user)
+  end
+
+  def competitor_team_id
+    SelectTeam.competitor_team_id(current_user)
   end
 end

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -2,6 +2,7 @@
 
 class API::MatchesController < ApplicationController
   before_action :set_show_page, only: [:show]
+  before_action :api_request
 
   def index
     @match = Match.all.order(:date).where(date: Time.zone.today..)
@@ -12,7 +13,7 @@ class API::MatchesController < ApplicationController
   end
 
   def api_request
-    set_match
+    set_match if current_user.favorite.team.standing.blank?
   end
 
   private

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -9,7 +9,7 @@ class API::MatchesController < ApplicationController
   end
 
   def show
-    @match_show = Match.all.where(team_matches_index: @team_id).order(:date)
+    @match_show = Match.all.where(team_id: @team_id).order(:date)
   end
 
   def api_request

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -5,7 +5,11 @@ class API::MatchesController < ApplicationController
   before_action :api_request
 
   def index
-    @match = Match.all.order(:date).where(date: Time.zone.today..)
+    favorite_team = current_user.favorite.team
+    competitors = current_user.competitor.map(&:team_id)
+    teams = competitors.unshift(favorite_team.id)
+    match = Match.all.order(:date).where(date: Time.zone.today..).where(team_id: teams)
+    @match = match
   end
 
   def show
@@ -13,7 +17,7 @@ class API::MatchesController < ApplicationController
   end
 
   def api_request
-    set_match if current_user.favorite.team.standing.blank?
+    set_match if current_user.favorite.team.match.blank?
   end
 
   private
@@ -23,7 +27,6 @@ class API::MatchesController < ApplicationController
   end
 
   def set_match
-    Match.delete_all
     MatchRequest.league(api_request_url)
   end
 

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -38,6 +38,6 @@ class API::MatchesController < ApplicationController
   end
 
   def competitor_teams
-    SelectTeam.competitor(current_user)
+    SelectTeam.competitor_team_api_id(current_user)
   end
 end

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -30,7 +30,7 @@ class API::StandingsController < ApplicationController
   end
 
   def competitor_team_api_id
-    SelectTeam.competitor(current_user)
+    SelectTeam.competitor_team_api_id(current_user)
   end
 
   def league_api_id(favorite_team)

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -5,7 +5,11 @@ class API::StandingsController < ApplicationController
   before_action :api_request
 
   def index
-    @standing = Standing.all
+    favorite_team = current_user.favorite.team.id
+    competitor_teams = current_user.competitor.map(&:team_id)
+    teams = competitor_teams.unshift(favorite_team)
+    standing = Standing.where(team_id: teams)
+    @standing = standing
   end
 
   def show; end
@@ -17,7 +21,6 @@ class API::StandingsController < ApplicationController
   private
 
   def set_standing
-    Standing.delete_all
     StandingRequest.league(api_request_url)
   end
 

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -5,11 +5,7 @@ class API::StandingsController < ApplicationController
   before_action :api_request
 
   def index
-    favorite_team = current_user.favorite.team.id
-    competitor_teams = current_user.competitor.map(&:team_id)
-    teams = competitor_teams.unshift(favorite_team)
-    standing = Standing.where(team_id: teams)
-    @standing = standing
+    @standing = Standing.where(team_id: selected_team_ids)
   end
 
   def show; end
@@ -27,6 +23,14 @@ class API::StandingsController < ApplicationController
   def api_request_url
     team_numbers = competitor_team_api_id.unshift(favorite_team.api_id)
     team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id(favorite_team)}&season=#{Year.season}&team=#{number}") }
+  end
+
+  def selected_team_ids
+    competitor_team_id.unshift(current_user.favorite.team.id)
+  end
+
+  def competitor_team_id
+    SelectTeam.competitor_team_id(current_user)
   end
 
   def competitor_team_api_id

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -2,6 +2,7 @@
 
 class API::StandingsController < ApplicationController
   before_action :authenticate_user!
+  before_action :api_request
 
   def index
     @standing = Standing.all
@@ -10,7 +11,7 @@ class API::StandingsController < ApplicationController
   def show; end
 
   def api_request
-    set_standing
+    set_standing if current_user.favorite.team.standing.blank?
   end
 
   private

--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -34,6 +34,6 @@ class API::UpdateMatchesController < ApplicationController
   end
 
   def competitor_teams
-    SelectTeam.competitor(current_user)
+    SelectTeam.competitor_team_api_id(current_user)
   end
 end

--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -5,7 +5,11 @@ class API::UpdateMatchesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @match = Match.all.order(:date).where(date: Time.zone.today..)
+    favorite_team = current_user.favorite.team
+    competitors = current_user.competitor.map(&:team_id)
+    teams = competitors.unshift(favorite_team.id)
+    match = Match.all.order(:date).where(date: Time.zone.today..).where(team_id: teams)
+    @match = match
   end
 
   def batch_request
@@ -15,7 +19,10 @@ class API::UpdateMatchesController < ApplicationController
   private
 
   def api_request
-    Match.delete_all
+    favorite_team = current_user.favorite.team
+    competitors = current_user.competitor.map(&:team_id)
+    teams = competitors.unshift(favorite_team.id)
+    Match.all.where(team_id: teams).delete_all
     MatchRequest.league(api_request_url)
   end
 

--- a/app/controllers/api/update_matches_controller.rb
+++ b/app/controllers/api/update_matches_controller.rb
@@ -5,35 +5,32 @@ class API::UpdateMatchesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    favorite_team = current_user.favorite.team
-    competitors = current_user.competitor.map(&:team_id)
-    teams = competitors.unshift(favorite_team.id)
-    match = Match.all.order(:date).where(date: Time.zone.today..).where(team_id: teams)
-    @match = match
-  end
-
-  def batch_request
-    api_request
+    @match = Match.all.order(:date).where(date: Time.zone.today..).where(team_id: selected_team_ids)
   end
 
   private
 
   def api_request
-    favorite_team = current_user.favorite.team
-    competitors = current_user.competitor.map(&:team_id)
-    teams = competitors.unshift(favorite_team.id)
-    Match.all.where(team_id: teams).delete_all
+    Match.all.where(team_id: selected_team_ids).delete_all
     MatchRequest.league(api_request_url)
   end
 
   def api_request_url
-    api_id = competitor_teams.unshift(current_user.favorite.team.api_id)
+    api_id = competitor_team_api_id.unshift(current_user.favorite.team.api_id)
     api_id.map do |i|
       URI("https://v3.football.api-sports.io/fixtures?&season=#{Year.season}&team=#{i}&from=#{Time.zone.now.prev_month.strftime('%Y-%m-%d')}&to=#{Time.zone.now.next_month.strftime('%Y-%m-%d')}")
     end
   end
 
-  def competitor_teams
+  def selected_team_ids
+    competitor_team_id.unshift(current_user.favorite.team.id)
+  end
+
+  def competitor_team_id
+    SelectTeam.competitor_team_id(current_user)
+  end
+
+  def competitor_team_api_id
     SelectTeam.competitor_team_api_id(current_user)
   end
 end

--- a/app/controllers/api/update_standings_controller.rb
+++ b/app/controllers/api/update_standings_controller.rb
@@ -5,7 +5,11 @@ class API::UpdateStandingsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @standing = Standing.all
+    favorite_team = current_user.favorite.team.id
+    competitor_teams = current_user.competitor.map(&:team_id)
+    teams = competitor_teams.unshift(favorite_team)
+    standing = Standing.where(team_id: teams)
+    @standing = standing
   end
 
   def batch_request
@@ -15,7 +19,10 @@ class API::UpdateStandingsController < ApplicationController
   private
 
   def api_request
-    Standing.delete_all
+    favorite_team = current_user.favorite.team.id
+    competitor_teams = current_user.competitor.map(&:team_id)
+    teams = competitor_teams.unshift(favorite_team)
+    Standing.all.where(team_id: teams).delete_all
     StandingRequest.league(api_request_url)
   end
 

--- a/app/controllers/api/update_standings_controller.rb
+++ b/app/controllers/api/update_standings_controller.rb
@@ -32,7 +32,7 @@ class API::UpdateStandingsController < ApplicationController
   end
 
   def competitor_team_api_id
-    SelectTeam.competitor(current_user)
+    SelectTeam.competitor_team_api_id(current_user)
   end
 
   def league_api_id(favorite_team)

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -186,21 +186,21 @@ export default {
     }
 
     const favoriteMatches = computed(() =>
-      data.matches.filter((f) => f.team_matches_index === data.favorite.team.id)
+      data.matches.filter((f) => f.team_id === data.favorite.team.id)
     )
     const firstCompetitorTeamsMatches = computed(() =>
       data.matches.filter(
-        (f) => f.team_matches_index === data.competitors[0].team_id
+        (f) => f.team_id === data.competitors[0].team_id
       )
     )
     const secondCompetitorTeamsMatches = computed(() =>
       data.matches.filter(
-        (f) => f.team_matches_index === data.competitors[1].team_id
+        (f) => f.team_id === data.competitors[1].team_id
       )
     )
     const thirdCompetitorTeamsMatches = computed(() =>
       data.matches.filter(
-        (f) => f.team_matches_index === data.competitors[2].team_id
+        (f) => f.team_id === data.competitors[2].team_id
       )
     )
 

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -8,17 +8,7 @@
       <p class="has-text-centered has-text-weight-bold mb-4">
         優勝・欧州カップ戦出場権・残留争いを楽しもう
       </p>
-      <div
-        v-if="!firstCompetitorTeamsMatches.length"
-        class="first-api-request has-text-centered">
-        <p>試合情報を取得してください</p>
-        <button
-          class="button my-1 color-button has-text-white"
-          @click="dataUpdate">
-          試合情報を取得する
-        </button>
-        <MatchListLoader />
-      </div>
+      <MatchListLoader v-if="!favoriteMatches.length"/>
       <div v-else>
         <div class="mb-3 has-text-right">
           <p>更新日:{{ updateDate(favoriteMatches[0].created_at) }}</p>

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -8,7 +8,7 @@
       <p class="has-text-centered has-text-weight-bold mb-4">
         優勝・欧州カップ戦出場権・残留争いを楽しもう
       </p>
-      <MatchListLoader v-if="!favoriteMatches.length"/>
+      <MatchListLoader v-if="!favoriteMatches.length" />
       <div v-else>
         <div class="mb-3 has-text-right">
           <p>更新日:{{ updateDate(favoriteMatches[0].created_at) }}</p>
@@ -189,19 +189,13 @@ export default {
       data.matches.filter((f) => f.team_id === data.favorite.team.id)
     )
     const firstCompetitorTeamsMatches = computed(() =>
-      data.matches.filter(
-        (f) => f.team_id === data.competitors[0].team_id
-      )
+      data.matches.filter((f) => f.team_id === data.competitors[0].team_id)
     )
     const secondCompetitorTeamsMatches = computed(() =>
-      data.matches.filter(
-        (f) => f.team_id === data.competitors[1].team_id
-      )
+      data.matches.filter((f) => f.team_id === data.competitors[1].team_id)
     )
     const thirdCompetitorTeamsMatches = computed(() =>
-      data.matches.filter(
-        (f) => f.team_id === data.competitors[2].team_id
-      )
+      data.matches.filter((f) => f.team_id === data.competitors[2].team_id)
     )
 
     const date = new Date()

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Match < ApplicationRecord
-  validates :team_matches_index, presence: true
+  validates :team_id, presence: true
   validates :season, presence: true
   validates :date, presence: true
   validates :competition_name, presence: true

--- a/app/models/match_request.rb
+++ b/app/models/match_request.rb
@@ -25,6 +25,7 @@ class MatchRequest
       match = Match.new
       match.season = [api][0]['parameters']['season']
       current_team = Team.find_by(api_id: [api][0]['parameters']['team'])
+      match.team_id = current_team.id
       match.team_matches_index = current_team.id
       match.date = [api][0]['response'][a]['fixture']['date']
       stadium = [api][0]['response'][a]['fixture']['venue']['name']

--- a/app/models/match_request.rb
+++ b/app/models/match_request.rb
@@ -26,7 +26,6 @@ class MatchRequest
       match.season = [api][0]['parameters']['season']
       current_team = Team.find_by(api_id: [api][0]['parameters']['team'])
       match.team_id = current_team.id
-      match.team_matches_index = current_team.id
       match.date = [api][0]['response'][a]['fixture']['date']
       stadium = [api][0]['response'][a]['fixture']['venue']['name']
       match.home_and_away = stadium == current_team.stadium ? 'HOME' : 'AWAY'

--- a/app/models/select_team.rb
+++ b/app/models/select_team.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class SelectTeam
-  def self.competitor(user)
-    competitor_team_id = user.competitor.map(&:team_id)
-    competitor_team_id.map { |c| Team.find(c).api_id }
+  def self.competitor_team_api_id(user)
+    competitor_team = competitor_team_id(user)
+    competitor_team.map { |c| Team.find(c).api_id }
+  end
+
+  def self.competitor_team_id(user)
+    user.competitor.map(&:team_id)
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,4 +10,5 @@ class Team < ApplicationRecord
   has_one :favorite, dependent: :destroy
   has_many :competitor, dependent: :destroy
   has_one :standing, dependent: :destroy
+  has_many :match, dependent: :destroy
 end

--- a/app/views/api/matches/index.json.jbuilder
+++ b/app/views/api/matches/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at
+json.array! @match, :team_id, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at

--- a/app/views/api/matches/show.json.jbuilder
+++ b/app/views/api/matches/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match_show, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :home_score, :away_score, :home_team_name, :away_team_name, :home_logo, :away_logo
+json.array! @match_show, :team_id, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :home_score, :away_score, :home_team_name, :away_team_name, :home_logo, :away_logo

--- a/app/views/api/update_matches/index.json.jbuilder
+++ b/app/views/api/update_matches/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at
+json.array! @match, :team_id, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at

--- a/db/migrate/20220901073929_add_columns_to_matches.rb
+++ b/db/migrate/20220901073929_add_columns_to_matches.rb
@@ -1,0 +1,5 @@
+class AddColumnsToMatches < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :matches, :team, foreign_key: true
+  end
+end

--- a/db/migrate/20220902234525_remove_team_matches_index_from_matches.rb
+++ b/db/migrate/20220902234525_remove_team_matches_index_from_matches.rb
@@ -1,0 +1,5 @@
+class RemoveTeamMatchesIndexFromMatches < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :matches, :team_matches_index, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_01_073929) do
+ActiveRecord::Schema.define(version: 2022_09_02_234525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 2022_09_01_073929) do
   end
 
   create_table "matches", force: :cascade do |t|
-    t.integer "team_matches_index"
     t.string "season", null: false
     t.date "date", null: false
     t.string "competition_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_29_075031) do
+ActiveRecord::Schema.define(version: 2022_09_01_073929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,8 @@ ActiveRecord::Schema.define(version: 2022_08_29_075031) do
     t.string "away_team_name"
     t.string "home_logo"
     t.string "away_logo"
+    t.bigint "team_id"
+    t.index ["team_id"], name: "index_matches_on_team_id"
   end
 
   create_table "standings", force: :cascade do |t|
@@ -109,6 +111,7 @@ ActiveRecord::Schema.define(version: 2022_08_29_075031) do
   add_foreign_key "competitors", "users"
   add_foreign_key "favorites", "teams"
   add_foreign_key "favorites", "users"
+  add_foreign_key "matches", "teams"
   add_foreign_key "standings", "teams"
   add_foreign_key "teams", "leagues"
 end

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :match do
     id { 1 }
     date { 'Wed, 12 Jan 2022' }
-    team_matches_index { 1 }
+    team_id { 1 }
     season { 2021 }
     competition_name { 'UEFA Champions League' }
     competition_logo { 'https://media.api-sports.io/football/leagues/2.png' }

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Match, type: :model do
     expect(match.errors[:date]).to include('を入力してください')
   end
 
-  it 'is valid without a team_matches_index' do
-    match = FactoryBot.build(:match, team_matches_index: nil)
+  it 'is valid without a team_id' do
+    match = FactoryBot.build(:match, team_id: nil)
 
     match.valid?
-    expect(match.errors[:team_matches_index]).to include('を入力してください')
+    expect(match.errors[:team_id]).to include('を入力してください')
   end
 
   it 'is valid without a season' do

--- a/spec/models/select_team_spec.rb
+++ b/spec/models/select_team_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe SelectTeam, type: :model do
 
   it 'is return the api_id of the following competitor team' do
     FactoryBot.create(:competitor, user: user, team: team)
-    expect(SelectTeam.competitor(user)).to eq [42]
+    expect(SelectTeam.competitor_team_api_id(user)).to eq [42]
   end
 
   it 'is not return when not following competitor team' do
-    expect(SelectTeam.competitor(user)).to eq []
+    expect(SelectTeam.competitor_team_api_id(user)).to eq []
   end
 end


### PR DESCRIPTION
## 対応した issue
#249 

## 対応内容・対応背景・妥協点
- 現状ではデータを更新する際に`Standing.delete_all`という方法をとっているので、他のユーザーのデータも消えてしまう。
- アカウント作成後に手動でデータを更新しなければならなかった
  - ローディングと同時に表示されていたためわかりにくかった
## やったこと
- teamとmatchの関連付けをした
- データの取得と更新はユーザーが登録したチームだけを対象に行うようにした
- アカウント作成後は自動で情報を取得できるようにした

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
