### PR TITLE
twitter cardの画像サイズをlarge_imageに変更した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
       },
       twitter: {
         title: :title,
-        card: 'summary',
+        card: 'summary_large_image',
         site: '@ryo0270590',
         description: :description,
         image: image_url('logo_black_white.png'),


### PR DESCRIPTION
## 対応した issue
#257 
## 対応内容・対応背景・妥協点
Twitter cardの画像サイズが小さかった
## やったこと
- 画像サイズを`summary`から`summary_large_image`に変更した

## UI before / after
### before
<img width="584" alt="スクリーンショット 2022-09-04 5 57 18" src="https://user-images.githubusercontent.com/62058863/188287570-154a9935-62b8-4c53-98f1-5e5b4ec32329.png">

### after

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
