### PR TITLE
モバイルディスプレイの時にリーグ選択のタブが画面に収まっていなかったのを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -163,7 +163,7 @@ input.how-to-team-select:hover {
   }
 }
 
-.mobile-display {
+.not-displayed-when-with-mobile-display {
   @include mobile {
     display: none;
   }

--- a/app/javascript/components/page/TeamSchedule/list/MatchResultList.vue
+++ b/app/javascript/components/page/TeamSchedule/list/MatchResultList.vue
@@ -28,7 +28,7 @@
       <!-- columns -->
       <div class="match-list columns is-mobile m-auto">
         <p
-          class="column m-auto has-text-centered has-text-weight-bold is-size-3-tablet mobile-display">
+          class="column m-auto has-text-centered has-text-weight-bold is-size-3-tablet not-displayed-when-with-mobile-display">
           {{ result.home_team_name }}
         </p>
         <div class="column schedule-column-logo m-auto">
@@ -52,7 +52,7 @@
         </div>
         <!-- schedule-column-logo -->
         <p
-          class="column has-text-centered has-text-weight-bold m-auto is-size-3-tablet mobile-display">
+          class="column has-text-centered has-text-weight-bold m-auto is-size-3-tablet not-displayed-when-with-mobile-display">
           {{ result.away_team_name }}
         </p>
       </div>

--- a/app/javascript/components/page/TeamSchedule/list/MatchScheduleList.vue
+++ b/app/javascript/components/page/TeamSchedule/list/MatchScheduleList.vue
@@ -28,7 +28,7 @@
       <!-- columns -->
       <div class="match-list columns is-mobile mx-auto">
         <p
-          class="column my-auto has-text-weight-bold is-size-3-tablet mobile-display">
+          class="column my-auto has-text-weight-bold is-size-3-tablet not-displayed-when-with-mobile-display">
           {{ schedule.home_team_name }}
         </p>
         <div class="column has-text-centered">
@@ -47,7 +47,7 @@
             class="image team-logo mx-auto" />
         </div>
         <p
-          class="column my-auto has-text-weight-bold is-size-3-tablet mobile-display">
+          class="column my-auto has-text-weight-bold is-size-3-tablet not-displayed-when-with-mobile-display">
           {{ schedule.away_team_name }}
         </p>
       </div>

--- a/app/javascript/components/page/TeamSchedule/table/StandingData.vue
+++ b/app/javascript/components/page/TeamSchedule/table/StandingData.vue
@@ -26,7 +26,8 @@
             class="image" />
         </div>
         <!--favorite-team-logo column-->
-        <div class="favorite-team-name mobile-display my-auto column">
+        <div
+          class="favorite-team-name not-displayed-when-with-mobile-display my-auto column">
           <p class="has-text-weight-bold is-size-4">
             {{ standings.team_name }}
           </p>

--- a/app/javascript/components/page/TeamSchedule/table/TeamMatches.vue
+++ b/app/javascript/components/page/TeamSchedule/table/TeamMatches.vue
@@ -26,7 +26,8 @@
         :src="match.team_logo"
         alt="match-team-logo"
         class="image next-match-competition-logo" />
-      <p class="match-name mobile-display has-text-weight-bold">
+      <p
+        class="match-name not-displayed-when-with-mobile-display has-text-weight-bold">
         {{ match.team_name }}
       </p>
       <!-- match-name -->

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <h2
-      class="has-text-centered is-size-2-tablet is-size-4-mobile has-text-weight-bold">
+      class="has-text-centered is-size-2-tablet is-size-6-mobile has-text-weight-bold">
       応援しているチームを選んでください
     </h2>
     <div
@@ -24,11 +24,11 @@
     <div
       class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
       v-else>
-      <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
+      <router-link to="/competitors">ライバルチームのみ変更する</router-link>
     </div>
     <LeagueListLoader v-if="!data.leagues.length" />
     <div v-else>
-      <h3 class="has-text-centered is-size-3 my-4 has-text-weight-bold">
+      <h3 class="has-text-centered is-size-3 is-size-6-mobile my-4 has-text-weight-bold">
         リーグを選択
       </h3>
       <div class="tabs is-boxed is-fullwidth">
@@ -55,7 +55,7 @@
     <!-- else -->
     <TeamListLoader v-if="!teamFilter.length" />
     <div v-else>
-      <h3 class="has-text-centered is-size-3 my-6 has-text-weight-bold">
+      <h3 class="has-text-centered is-size-3 is-size-6-mobile my-6 has-text-weight-bold">
         チームを選択
       </h3>
       <div class="columns is-mobile is-flex-wrap-wrap has-text-centered">

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -31,7 +31,7 @@
       <h3 class="has-text-centered is-size-3 my-4 has-text-weight-bold">
         リーグを選択
       </h3>
-      <div class="tabs is-boxed is-fullwidth is-large">
+      <div class="tabs is-boxed is-fullwidth">
         <ul v-for="league in data.leagues" :key="league.id">
           <li
             @click="selectLeague(league)"
@@ -43,7 +43,7 @@
                 :src="league.logo"
                 alt="league_name"
                 class="image team-select-league-logo mr-2" />
-              <p class="is-size-6">
+              <p class="is-size-6 not-displayed-when-with-mobile-display">
                 {{ league.name }}
               </p>
             </a>

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -28,7 +28,8 @@
     </div>
     <LeagueListLoader v-if="!data.leagues.length" />
     <div v-else>
-      <h3 class="has-text-centered is-size-3 is-size-6-mobile my-4 has-text-weight-bold">
+      <h3
+        class="has-text-centered is-size-3 is-size-6-mobile has-text-weight-bold mt-3">
         リーグを選択
       </h3>
       <div class="tabs is-boxed is-fullwidth">
@@ -55,7 +56,8 @@
     <!-- else -->
     <TeamListLoader v-if="!teamFilter.length" />
     <div v-else>
-      <h3 class="has-text-centered is-size-3 is-size-6-mobile my-6 has-text-weight-bold">
+      <h3
+        class="has-text-centered is-size-3 is-size-6-mobile has-text-weight-bold my-3">
         チームを選択
       </h3>
       <div class="columns is-mobile is-flex-wrap-wrap has-text-centered">

--- a/spec/system/competitor_team_select_spec.rb
+++ b/spec/system/competitor_team_select_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'register selected competitor teams', type: :system, js: true do
     expect(page).to have_content '選んだチームを登録する'
   end
 
-  it 'ボタンがdisabledになっている', js: true do
+  it 'not selected when button is disabled', js: true do
     expect(page).to have_button 'チームの選択方法を決定する', disabled: true
   end
 end


### PR DESCRIPTION
## 対応した issue
#256 
## 対応内容・対応背景・妥協点
モバイルディスプレイの時にリーグ選択のタブが画面に収まっていなかったのを修正
## やったこと
- mobile displayの時はリーグ名を表示しないようにした
- mobile displayの時に`dislay: none`にするCSSのメソッド名を修正
　- mobile displayのときだけ表示されるクラスだと誤解される可能性があった
## UI before / after
### before
![image](https://user-images.githubusercontent.com/62058863/188258099-dce22984-0700-4c38-9acf-484eee6244ff.png)
### after
<img width="321" alt="スクリーンショット 2022-09-06 13 26 11" src="https://user-images.githubusercontent.com/62058863/188547280-2d540c2b-4b43-4655-bd6c-1f3c0695731a.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
