### PR TITLE
昨シーズンの順位と本拠地だとわかるように見出しを作った

### DIFF
--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -74,7 +74,7 @@
         :competitors="data.competitors"
         v-if="data.isShowingMessage" />
       <CompetitorValidation v-else />
-      <div class="columns is-mobile">
+      <div class="columns is-multiline is-mobile">
         <div
           class="column mx-auto"
           v-for="team in data.selectedTeams"
@@ -91,14 +91,14 @@
               :src="team.logo"
               class="image competitor-team-logo mx-auto pt-1" />
             <p
-              class="has-text-weight-medium mt-2 is-size-4-tablet is-size-7-mobile">
+              class="has-text-weight-medium mt-2 is-size-2-tablet is-size-7-mobile">
               {{ team.name }}
             </p>
-            <p class="has-text-weight-medium is-size-4-tablet is-size-7-mobile">
-              {{ team.last_season_rank }}位
+            <p class="has-text-weight-medium is-size-3-tablet is-size-5-mobile">
+              <span class="is-size-5-tablet is-size-7-mobile">21-22:</span>{{ team.last_season_rank }}<span>位</span>
             </p>
-            <p class="has-text-weight-medium is-size-4-tablet is-size-7-mobile">
-              {{ team.home_city }}
+            <p class="has-text-weight-medium is-size-3-tablet is-size-5-mobile">
+              <span class="is-size-5-tablet is-size-7-mobile">Home:</span>{{ team.home_city }}
             </p>
           </div>
           <!-- card -->

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -95,10 +95,12 @@
               {{ team.name }}
             </p>
             <p class="has-text-weight-medium is-size-3-tablet is-size-5-mobile">
-              <span class="is-size-5-tablet is-size-7-mobile">21-22:</span>{{ team.last_season_rank }}<span>位</span>
+              <span class="is-size-5-tablet is-size-7-mobile">21-22:</span
+              >{{ team.last_season_rank }}<span>位</span>
             </p>
             <p class="has-text-weight-medium is-size-3-tablet is-size-5-mobile">
-              <span class="is-size-5-tablet is-size-7-mobile">Home:</span>{{ team.home_city }}
+              <span class="is-size-5-tablet is-size-7-mobile">Home:</span
+              >{{ team.home_city }}
             </p>
           </div>
           <!-- card -->


### PR DESCRIPTION
## 対応した issue
#250 
## 対応内容・対応背景・妥協点
表示されているものが何を表していのかがわかりにくかった。
見出しをつけるようにした
## やったこと
- 順位と本拠地の前に見出しを作った
- モバイルでの表示の時は折り返されて表示されるようにした

## UI before / after
### before
<img width="1433" alt="スクリーンショット 2022-09-01 22 06 51" src="https://user-images.githubusercontent.com/62058863/188039243-8eb0806b-9245-4a2c-bdbd-057628d14f59.png">

### after
<img width="1425" alt="スクリーンショット 2022-09-06 14 01 47" src="https://user-images.githubusercontent.com/62058863/188550807-51db538f-29a2-407f-8b60-82123c4098fd.png">

<img width="331" alt="スクリーンショット 2022-09-06 14 01 59" src="https://user-images.githubusercontent.com/62058863/188550814-0050e6a3-13ad-4381-9c01-ea35ffae627d.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
