### PR TITLE
ボタンのコンポーネント化と必要に応じてアイコンを入れる

### DIFF
--- a/app/javascript/components/Molecules/BooleanButton/CompetitorSelectButton.vue
+++ b/app/javascript/components/Molecules/BooleanButton/CompetitorSelectButton.vue
@@ -1,0 +1,29 @@
+<template>
+  <router-link
+    to="/schedules"
+    v-if="competitors.length >= 1 && competitors.length <= 3">
+    <DetermineButton
+      class="color-button is-rounded has-text-white"
+      label="選んだチームを登録する" />
+  </router-link>
+  <DetermineButton
+    v-else
+    class="color-button is-rounded"
+    title="Disabled button"
+    disabled
+    label="選んだチームを登録する" />
+</template>
+<script>
+import DetermineButton from '../../atoms/Button/DetermineButton.vue'
+
+export default {
+  props: {
+    competitors: {
+      type: String
+    }
+  },
+  components: {
+    DetermineButton
+  }
+}
+</script>

--- a/app/javascript/components/Molecules/BooleanButton/FavoriteSelectButton.vue
+++ b/app/javascript/components/Molecules/BooleanButton/FavoriteSelectButton.vue
@@ -1,0 +1,27 @@
+<template>
+  <router-link to="/competitors" v-if="isChangeColorTeam">
+    <DetermineButton
+      label="応援しているチームを決定する"
+      class="is-rounded color-button has-text-white is-size-7-mobile mt-3" />
+  </router-link>
+  <DetermineButton
+    v-else
+    label="応援しているチームを決定する"
+    class="is-rounded color-button is-size-7-mobile mt-3"
+    title="Disabled button"
+    disabled />
+</template>
+<script>
+import DetermineButton from '../../atoms/Button/DetermineButton.vue'
+
+export default {
+  props: {
+    isChangeColorTeam: {
+      type: String
+    }
+  },
+  components: {
+    DetermineButton
+  }
+}
+</script>

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -108,19 +108,7 @@
         @click="selectAgain"
         class="is-rounded"
         label="チームの選び方を変更する" />
-      <router-link
-        to="/schedules"
-        v-if="data.competitors.length >= 1 && data.competitors.length <= 3">
-        <DetermineButton
-          class="color-button is-rounded has-text-white"
-          label="選んだチームを登録する" />
-      </router-link>
-      <DetermineButton
-        v-else
-        class="is-rounded"
-        label="選んだチームを登録する"
-        title="Disabled button"
-        disabled />
+      <CompetitorSelectButton :competitors="data.competitors" />
     </div>
     <!--自分でチーム選んでもらう -->
     <!-- v-show -->
@@ -166,19 +154,7 @@
           class="is-rounded"
           label="チームの選択方法を選び直す"
           @click="selectAgain" />
-        <router-link
-          to="/schedules"
-          v-if="data.competitors.length >= 1 && data.competitors.length <= 3">
-          <DetermineButton
-            class="color-button is-rounded has-text-white"
-            label="選んだチームを登録する" />
-        </router-link>
-        <DetermineButton
-          v-else
-          class="color-button is-rounded"
-          title="Disabled button"
-          disabled
-          label="選んだチームを登録する" />
+        <CompetitorSelectButton :competitors="data.competitors" />
       </div>
       <!-- buttons -->
     </div>
@@ -194,7 +170,8 @@ import CompetitorTeamCount from '../../modal/CompetitorTeamCount.vue'
 import TeamListLoader from '../../loader/TeamListLoader.vue'
 import BackToPageButton from '../../atoms/Button/BackToPageButton.vue'
 import BaseButton from '../../atoms/Button/BaseButton.vue'
-import DetermineButton from '../../atoms/Button/DetermineButton.vue'
+import DetermineButton from '../../atoms/Button/DetermineButton'
+import CompetitorSelectButton from '../../Molecules/BooleanButton/CompetitorSelectButton'
 
 export default {
   components: {
@@ -203,7 +180,8 @@ export default {
     CompetitorTeamCount,
     BackToPageButton,
     BaseButton,
-    DetermineButton
+    DetermineButton,
+    CompetitorSelectButton
   },
   setup() {
     const data = reactive({

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -1,11 +1,6 @@
 <template>
   <div class="container has-text-centered">
     <!-- ライバルチーム選択方法を選んでもらう -->
-    <div class="notification is-danger is-size-4" v-show="data.isSelected">
-      <button class="delete" @click="deleteMessage"></button>
-      ライバルチームの選択方法を一つ選んでください
-    </div>
-    <!-- notification -->
     <div v-show="data.isShowing">
       <div class="mx-auto">
         <h2
@@ -113,10 +108,13 @@
         @click="selectAgain"
         class="is-rounded"
         label="チームの選び方を変更する" />
-      <DetermineButton
-        v-if="data.competitors.length >= 1 && data.competitors.length <= 3"
-        class="color-button is-rounded has-text-white"
-        label="選んだチームを登録する" />
+      <router-link
+        to="/schedules"
+        v-if="data.competitors.length >= 1 && data.competitors.length <= 3">
+        <DetermineButton
+          class="color-button is-rounded has-text-white"
+          label="選んだチームを登録する" />
+      </router-link>
       <DetermineButton
         v-else
         class="is-rounded"
@@ -168,20 +166,19 @@
           class="is-rounded"
           label="チームの選択方法を選び直す"
           @click="selectAgain" />
-        <router-link to="/schedules">
+        <router-link
+          to="/schedules"
+          v-if="data.competitors.length >= 1 && data.competitors.length <= 3">
           <DetermineButton
             class="color-button is-rounded has-text-white"
-            label="選んだチームを登録する"
-            v-if="
-              data.competitors.length >= 1 && data.competitors.length <= 3
-            " />
-          <DetermineButton
-            v-else
-            class="color-button is-rounded"
-            title="Disabled button"
-            disabled
             label="選んだチームを登録する" />
         </router-link>
+        <DetermineButton
+          v-else
+          class="color-button is-rounded"
+          title="Disabled button"
+          disabled
+          label="選んだチームを登録する" />
       </div>
       <!-- buttons -->
     </div>

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -1,103 +1,101 @@
 <template>
   <div class="container">
-    <h2
-      class="has-text-centered is-size-2-tablet is-size-6-mobile has-text-weight-bold">
-      応援しているチームを選んでください
-    </h2>
-    <div
-      class="box team-select-description mt-3 mx-auto"
-      v-if="!data.competitors.length">
-      <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">
-        チーム選びの手順
-      </p>
-      <ol class="p-2 is-size-6-mobile has-text-centered">
-        <li class="p-1">あなたが応援しているチームを選びます。</li>
-        <li class="p-1">
-          1で選んだのと同じリーグの中からライバルチームを選びます。
-        </li>
-        <li class="p-1">
-          まずは応援しているチームが所属しているリーグを選んでください。
-        </li>
-      </ol>
-    </div>
-    <!-- box -->
-    <div
-      class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
-      v-else>
-      <router-link to="/competitors">ライバルチームのみ変更する</router-link>
-    </div>
-    <LeagueListLoader v-if="!data.leagues.length" />
-    <div v-else>
-      <h3
-        class="has-text-centered is-size-3 is-size-6-mobile has-text-weight-bold mt-3">
-        リーグを選択
-      </h3>
-      <div class="tabs is-boxed is-fullwidth">
-        <ul v-for="league in data.leagues" :key="league.id">
-          <li
-            @click="selectLeague(league)"
-            v-bind:class="{
-              'is-active': data.isChangeColorLeague === league.id
-            }">
-            <a>
-              <img
-                :src="league.logo"
-                alt="league_name"
-                class="image team-select-league-logo mr-2" />
-              <p class="is-size-6 not-displayed-when-with-mobile-display">
-                {{ league.name }}
-              </p>
-            </a>
+    <div class="section has-text-centered">
+      <h2
+        class="has-text-centered is-size-2-tablet is-size-6-mobile has-text-weight-bold">
+        応援しているチームを選んでください
+      </h2>
+      <div
+        class="box team-select-description mt-3 mx-auto"
+        v-if="!data.competitors.length">
+        <p class="is-size-4-tablet has-text-centered has-text-weight-semibold">
+          チーム選びの手順
+        </p>
+        <ol class="p-2 is-size-6-mobile has-text-centered">
+          <li class="p-1">あなたが応援しているチームを選びます。</li>
+          <li class="p-1">
+            1で選んだのと同じリーグの中からライバルチームを選びます。
           </li>
-        </ul>
+          <li class="p-1">
+            まずは応援しているチームが所属しているリーグを選んでください。
+          </li>
+        </ol>
       </div>
-      <!-- tabs -->
-    </div>
-    <!-- else -->
-    <TeamListLoader v-if="!teamFilter.length" />
-    <div v-else>
-      <h3
-        class="has-text-centered is-size-3 is-size-6-mobile has-text-weight-bold my-3">
-        チームを選択
-      </h3>
-      <div class="columns is-mobile is-flex-wrap-wrap has-text-centered">
-        <div
-          class="column is-one-fifth-tablet is-one-third-mobile has-text-centered"
-          v-for="team in teamFilter"
-          :key="team.id">
-          <div
-            class="card has-hover-action select-button"
-            @click="selectTeam(team)"
-            v-bind:class="{
-              'has-background-link-light is-selected':
-                data.isChangeColorTeam === team.id
-            }">
-            <img :src="team.logo" class="image mx-auto team-logo" />
-            <p
-              class="has-text-weight-semibold mt-2 is-size-6-tablet is-size-7-mobile is-break-all"
+      <!-- box -->
+      <div
+        class="has-text-right is-size-6-tablet is-size-7-mobile has-text-weight-bold mt-3"
+        v-else>
+        <router-link to="/competitors">ライバルチームのみ変更する</router-link>
+      </div>
+      <LeagueListLoader v-if="!data.leagues.length" />
+      <div v-else>
+        <h3
+          class="has-text-centered is-size-3 is-size-6-mobile has-text-weight-bold mt-3">
+          リーグを選択
+        </h3>
+        <div class="tabs is-boxed is-fullwidth">
+          <ul v-for="league in data.leagues" :key="league.id">
+            <li
+              @click="selectLeague(league)"
               v-bind:class="{
-                'has-text-weight-bold': data.isChangeColorTeam === team.id
+                'is-active': data.isChangeColorLeague === league.id
               }">
-              {{ team.name }}
-            </p>
-          </div>
-          <!-- card -->
+              <a>
+                <img
+                  :src="league.logo"
+                  alt="league_name"
+                  class="image team-select-league-logo mr-2" />
+                <p class="is-size-6 not-displayed-when-with-mobile-display">
+                  {{ league.name }}
+                </p>
+              </a>
+            </li>
+          </ul>
         </div>
-        <!-- column -->
+        <!-- tabs -->
       </div>
-      <!-- columns -->
+      <!-- else -->
+      <TeamListLoader v-if="!teamFilter.length" />
+      <div v-else>
+        <h3
+          class="has-text-centered is-size-3 is-size-6-mobile has-text-weight-bold my-3">
+          チームを選択
+        </h3>
+        <div class="columns is-mobile is-flex-wrap-wrap has-text-centered">
+          <div
+            class="column is-one-fifth-tablet is-one-third-mobile has-text-centered"
+            v-for="team in teamFilter"
+            :key="team.id">
+            <div
+              class="card has-hover-action select-button"
+              @click="selectTeam(team)"
+              v-bind:class="{
+                'has-background-link-light is-selected':
+                  data.isChangeColorTeam === team.id
+              }">
+              <img :src="team.logo" class="image mx-auto team-logo" />
+              <p
+                class="has-text-weight-semibold mt-2 is-size-6-tablet is-size-7-mobile is-break-all"
+                v-bind:class="{
+                  'has-text-weight-bold': data.isChangeColorTeam === team.id
+                }">
+                {{ team.name }}
+              </p>
+            </div>
+            <!-- card -->
+          </div>
+          <!-- column -->
+        </div>
+        <!-- columns -->
+      </div>
+      <!-- v-else -->
+      <router-link to="/competitors" v-if="data.isChangeColorTeam">
+        <DetermineButton
+          label="応援しているチームを決定する"
+          class="is-rounded color-button has-text-white mt-2" />
+      </router-link>
     </div>
-    <!-- v-else -->
-    <div v-if="data.isChangeColorTeam" class="has-text-centered">
-      <button class="color-button button is-rounded is-medium mt-6">
-        <router-link
-          to="/competitors"
-          class="has-text-white is-size-4-tablet is-size-7-mobile"
-          >応援しているチームを決定する</router-link
-        >
-      </button>
-    </div>
-    <!--has-text-centered -->
+    <!--section -->
   </div>
   <!-- .container -->
 </template>
@@ -107,11 +105,13 @@ import axios from 'axios'
 import { reactive, onMounted, computed } from 'vue'
 import LeagueListLoader from '../loader/LeagueListLoader'
 import TeamListLoader from '../loader/TeamListLoader'
+import DetermineButton from '../atoms/Button/DetermineButton'
 
 export default {
   components: {
     TeamListLoader,
-    LeagueListLoader
+    LeagueListLoader,
+    DetermineButton
   },
   setup() {
     const data = reactive({

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -92,17 +92,7 @@
         <!-- columns -->
       </div>
       <!-- v-else -->
-      <router-link to="/competitors" v-if="data.isChangeColorTeam">
-        <DetermineButton
-          label="応援しているチームを決定する"
-          class="is-rounded color-button has-text-white is-size-7-mobile mt-3" />
-      </router-link>
-      <DetermineButton
-        v-else
-        label="応援しているチームを決定する"
-        class="is-rounded color-button is-size-7-mobile mt-3"
-        title="Disabled button"
-        disabled />
+      <FavoriteSelectButton :isChangeColorTeam="data.isChangeColorTeam" />
     </div>
     <!--section -->
   </div>
@@ -114,13 +104,13 @@ import axios from 'axios'
 import { reactive, onMounted, computed } from 'vue'
 import LeagueListLoader from '../loader/LeagueListLoader'
 import TeamListLoader from '../loader/TeamListLoader'
-import DetermineButton from '../atoms/Button/DetermineButton'
+import FavoriteSelectButton from '../Molecules/BooleanButton/FavoriteSelectButton.vue'
 
 export default {
   components: {
     TeamListLoader,
     LeagueListLoader,
-    DetermineButton
+    FavoriteSelectButton
   },
   setup() {
     const data = reactive({

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -43,7 +43,7 @@
               <a>
                 <img
                   :src="league.logo"
-                  alt="league_name"
+                  :alt="league.name"
                   class="image team-select-league-logo mr-2" />
                 <p class="is-size-6 not-displayed-when-with-mobile-display">
                   {{ league.name }}
@@ -73,7 +73,10 @@
                 'has-background-link-light is-selected':
                   data.isChangeColorTeam === team.id
               }">
-              <img :src="team.logo" class="image mx-auto team-logo" />
+              <img
+                :src="team.logo"
+                :alt="team.name"
+                class="image mx-auto team-logo" />
               <p
                 class="has-text-weight-semibold mt-2 is-size-6-tablet is-size-7-mobile is-break-all"
                 v-bind:class="{
@@ -92,8 +95,14 @@
       <router-link to="/competitors" v-if="data.isChangeColorTeam">
         <DetermineButton
           label="応援しているチームを決定する"
-          class="is-rounded color-button has-text-white mt-2" />
+          class="is-rounded color-button has-text-white is-size-7-mobile mt-3" />
       </router-link>
+      <DetermineButton
+        v-else
+        label="応援しているチームを決定する"
+        class="is-rounded color-button is-size-7-mobile mt-3"
+        title="Disabled button"
+        disabled />
     </div>
     <!--section -->
   </div>

--- a/app/javascript/components/request_error/NotFound.vue
+++ b/app/javascript/components/request_error/NotFound.vue
@@ -1,14 +1,25 @@
 <template>
   <div class="container">
-    <div class="box">
-      <h1 class="is-size-1 has-text-centered has-text-weight-bold">404</h1>
-      <h2 class="is-size-3 has-text-centered py-2">
-        お探しのページが見つかりませんでした
-      </h2>
-      <p class="py-2">ご指定のページは削除されたか、移動した可能性があります</p>
+    <div class="section has-text-centered">
+      <div class="box">
+        <h1 class="is-size-1 has-text-weight-bold">404</h1>
+        <h2 class="is-size-3 py-2">お探しのページが見つかりませんでした</h2>
+        <p class="py-2">
+          ご指定のページは削除されたか、移動した可能性があります
+        </p>
+      </div>
+      <router-link to="/schedules">
+        <BackToPageButton class="is-rounded" label="日程一覧に戻る" />
+      </router-link>
     </div>
-    <button class="button is-rounded is-medium mx-auto">
-      <router-link to="/schedules">日程一覧に戻る</router-link>
-    </button>
   </div>
 </template>
+<script>
+import BackToPageButton from '../atoms/Button/BackToPageButton.vue'
+
+export default {
+  components: {
+    BackToPageButton
+  }
+}
+</script>

--- a/spec/system/competitor_team_select_spec.rb
+++ b/spec/system/competitor_team_select_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe 'register selected competitor teams', type: :system, js: true do
 
   it 'select teams that were close to last seasons standings', js: true do
     expect(page).to have_content 'ライバルチームの選び方を選択してください'
+    expect(page).to have_button 'チームの選択方法を決定する', disabled: true
     choose '昨シーズンの順位が近いチームを選ぶ'
     click_button 'チームの選択方法を決定する'
+    expect(page).to have_button '選んだチームを登録する', disabled: true
     expect(page).to have_content 'Manchester United'
     expect(page).to_not have_content 'Tottenham'
     all('img')[1].click
@@ -29,8 +31,10 @@ RSpec.describe 'register selected competitor teams', type: :system, js: true do
   end
 
   it 'select team that is close to home', js: true do
+    expect(page).to have_button 'チームの選択方法を決定する', disabled: true
     choose '本拠地が近いチームを選ぶ'
     click_button 'チームの選択方法を決定する'
+    expect(page).to have_button '選んだチームを登録する', disabled: true
     expect(page).to have_content 'Tottenham'
     expect(page).to_not have_content 'Manchester United'
     all('img')[1].click
@@ -39,8 +43,10 @@ RSpec.describe 'register selected competitor teams', type: :system, js: true do
   end
 
   it 'select competitor teams by self', js: true do
+    expect(page).to have_button 'チームの選択方法を決定する', disabled: true
     choose '自分でライバルチームを選ぶ'
     click_button 'チームの選択方法を決定する'
+    expect(page).to have_button '選んだチームを登録する', disabled: true
     expect(page).to have_content 'Tottenham'
     expect(page).to have_content 'Manchester United'
     expect(page).to have_content '残り3チーム登録できます'

--- a/spec/system/favorite_team_select_spec.rb
+++ b/spec/system/favorite_team_select_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe 'register selected a favorite team', type: :system, js: true do
 
   it 'select one of the teams shown and a button will appear', js: true do
     expect(page).to have_content 'Premier League'
+    expect(page).to have_button '応援しているチームを決定する', disabled: true
     sleep 2.0
     all('img')[1].click
     expect(page).to have_content 'Arsenal'
     all('img')[3].click
-    expect(page).to have_content '応援しているチームを決定する'
+    expect(page).to have_button '応援しているチームを決定する', disabled: false
   end
 end


### PR DESCRIPTION
## 対応した issue
#264 
## 対応内容・対応背景・妥協点
ボタンだけでは、押下後に何が起こるかイメージしにくい
## やったこと
- 404ページのボタンをコンポーネント化
  - レイアウトもついでに修正
- ボタンのコンポーネントを使うようにした
- 条件分岐でボタン表示しているところをコンポーネント化した
- ボタンの表示が変わったのでテストを修正した
## UI before / after
### 404
#### before
<img width="1919" alt="スクリーンショット 2022-09-06 16 31 08" src="https://user-images.githubusercontent.com/62058863/188575552-2361a042-fea6-49ff-a416-70270e1cd953.png">

#### after
<img width="1920" alt="スクリーンショット 2022-09-06 16 31 26" src="https://user-images.githubusercontent.com/62058863/188575565-64ca55ba-cf9a-4e3f-b759-f691e248cdb3.png">

### FavoriteTeamSelect
#### before

<img width="1454" alt="スクリーンショット 2022-09-06 23 00 11" src="https://user-images.githubusercontent.com/62058863/188655107-b56219ea-1b30-481b-a8c9-b18ef5a03ce7.png">

#### after
<img width="1483" alt="スクリーンショット 2022-09-06 23 00 03" src="https://user-images.githubusercontent.com/62058863/188655081-501f94d2-ae5c-442c-80ba-3e32cb82b8fc.png">

## テスト



- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
