### PR TITLE
ライバルチーム選択画面のレイアウトを修正と、同じ本拠地のチームがいないときのメッセージを作成

### DIFF
--- a/app/javascript/components/Organism/SelectedCompetitorTeamList.vue
+++ b/app/javascript/components/Organism/SelectedCompetitorTeamList.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="columns is-multiline is-mobile">
-    <div class="column is-one-third mx-auto" v-for="team in teams" :key="team.id">
+    <SorryMessage
+      v-if="teams.length === 0"
+      class="mx-auto"
+      label="同じ本拠地のチームがありません。 他の方法でチームを選んでください" />
+    <div
+      class="column is-one-third mx-auto"
+      v-for="team in teams"
+      :key="team.id">
       <div
         class="card has-hover-action select-button"
         @click="followTeam(team)"
@@ -30,7 +37,12 @@
   <!-- columns -->
 </template>
 <script>
+import SorryMessage from '../atoms/SorryMessage.vue'
+
 export default {
+  components: {
+    SorryMessage
+  },
   props: ['teams', 'competitors'],
   setup(props, context) {
     const followTeam = (team) => {

--- a/app/javascript/components/Organism/SelectedCompetitorTeamList.vue
+++ b/app/javascript/components/Organism/SelectedCompetitorTeamList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="columns is-multiline is-mobile">
-    <div class="column mx-auto" v-for="team in teams" :key="team.id">
+    <div class="column is-one-third mx-auto" v-for="team in teams" :key="team.id">
       <div
         class="card has-hover-action select-button"
         @click="followTeam(team)"

--- a/app/javascript/components/atoms/SorryMessage.vue
+++ b/app/javascript/components/atoms/SorryMessage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="box">
+    <p class="is-size-2">Sorry...</p>
+    <p class="mt-2">{{ label }}</p>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    label: {
+      type: String
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## 対応した issue
#186 
#274 
## 対応内容・対応背景・妥協点
- 同じ本拠地のチームが多いときにレイアウトが崩れる
- 同じ本拠地のチームがいないときにメッセージが何も表示されない
## やったこと
- チームリストの幅を設定した
- 同じ本拠地のチームがいないときに、「同じ本拠地のチームはいません」というメッセージが表示されるようにした
この PR 内でやったことを書く

## UI before / after
### レイアウト
#### before
<img width="1314" alt="ライバルチームを登録___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189604462-b7a96f74-9464-4552-a33b-b632c00a1b7e.png">

#### after
<img width="1324" alt="ライバルチームを登録___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189604491-dfdc5424-71b5-4125-9910-2be56722b5de.png">

### メッセージ
#### before
<img width="1418" alt="ライバルチームを登録___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189604379-84c2618a-05ff-4697-8dfc-b5a1d4114594.png">

#### after
<img width="1374" alt="ライバルチームを登録___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189604352-42182cb8-0deb-47f5-b7af-15a7060ebf6e.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
