### PR TITLE
ボックスの間にマージンを追加

### DIFF
--- a/app/javascript/components/Organism/table/TeamScheduleBox.vue
+++ b/app/javascript/components/Organism/table/TeamScheduleBox.vue
@@ -1,7 +1,7 @@
 <template>
   <div clsss="main-page">
     <div
-      class="box standing-and-matches columns mb-3"
+      class="box standing-and-matches columns my-6"
       @click="selectTeam(standings)">
       <StandingData
         :standings="standings"


### PR DESCRIPTION
## 対応した issue
#276
## 対応内容・対応背景・妥協点
メインページでライバルチームのボックスが重なっている
## やったこと
- box間にマージンを入れた

## UI before / after
### before
<img width="1310" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189609077-9b9e7928-61bd-447e-904b-873d558f75f4.png">

### after
<img width="1323" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189609031-48f15407-49bf-4dda-a01b-819101fb2b6e.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
