### PR TITLE
バーガーメニューのレイアウトを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -316,3 +316,15 @@ $button-color: #6246ea;
 .devise-page-width {
   width: 24rem;
 }
+
+.burger-menu-item.button {
+  @include mobile {
+    width: 8rem;
+  }
+}
+
+.navbar-end {
+  @include mobile {
+    margin-top: 1rem;
+  }
+}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,10 +28,10 @@ html
         #targetMenu.navbar-menu.has-background-main
           .navbar-start.m-auto
             - if user_signed_in?
-              ul
-                li = link_to 'HOME', root_path, class: 'burger-menu-item navbar-item home has-text-white has-text-weight-medium'
-                li = link_to 'TEAM', '/leagues', class: 'burger-menu-item navbar-item has-text-white has-text-weight-medium'
-                li = link_to 'ACCOUNT', edit_user_registration_path, class: 'burger-menu-item navbar-item has-text-white has-text-weight-medium'
+              .columns
+                = link_to 'HOME', root_path, class: 'column burger-menu-item navbar-item home has-text-white has-text-weight-medium'
+                = link_to 'TEAM', '/leagues', class: 'column burger-menu-item navbar-item has-text-white has-text-weight-medium'
+                = link_to 'ACCOUNT', edit_user_registration_path, class: 'column burger-menu-item navbar-item has-text-white has-text-weight-medium'
           .navbar-end.my-auto
             - if user_signed_in?
                 = link_to 'Log out', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item button is-small is-rounded'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -32,12 +32,12 @@ html
                 = link_to 'HOME', root_path, class: 'column burger-menu-item navbar-item home has-text-white has-text-weight-medium'
                 = link_to 'TEAM', '/leagues', class: 'column burger-menu-item navbar-item has-text-white has-text-weight-medium'
                 = link_to 'ACCOUNT', edit_user_registration_path, class: 'column burger-menu-item navbar-item has-text-white has-text-weight-medium'
-          .navbar-end.my-auto
+          .navbar-end.mt-4
             - if user_signed_in?
-                = link_to 'Log out', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item button is-small is-rounded'
+                = link_to 'Log out', destroy_user_session_path, method: :delete, class: 'burger-menu-item navbar-item button is-small is-rounded m-auto'
             - else
               .navbar-item
-                = link_to 'Log in', new_user_session_path, class: 'burger-menu-item navbar-item button is-small is-rounded'
+                = link_to 'Log in', new_user_session_path, class: 'burger-menu-item navbar-item button is-small is-rounded m-auto'
       p
         .notice.is-size-4.p-5.has-text-centered.has-text-info
           = notice


### PR DESCRIPTION
## 対応した issue
#278 
## 対応内容・対応背景・妥協点
- バーガーメニューのレイアウトが崩れている
## やったこと
- バーガーメニューのCSSを追加
- buttonのレイアウトを修正

## UI before / after
### before
<img width="414" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189793514-d6e53e15-028e-4fc7-97ae-e1a730262bcf.png">

### after
<img width="374" alt="リーグ戦情報___Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/189793494-91b07a23-f2c3-46cd-a565-6fe35ca0ccc2.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
