### PR TITLE
ユーザー認証ページがレスポンシブ対応になっていなかった

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -315,6 +315,9 @@ $button-color: #6246ea;
 
 .devise-page-width {
   width: 24rem;
+  @include mobile {
+    width: 14rem;
+  }
 }
 
 .burger-menu-item.button {

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,33 +1,31 @@
-.section.mx-auto
-  h2.is-size-2.has-text-weight-semibold.has-text-centered
-    = t('.edit')
-  = form_with model: @user, url: user_registration_path, html: { method: :put } do |f|
-    = render 'devise/shared/error_messages', resource: resource
-    .container
-      .field.has-text-left.has-text-weight-semibold.my-4
-        = f.label :email
-        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
-        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-          div
+.container
+  .section
+    h2.is-size-2.is-size-4-mobile.has-text-weight-semibold.has-text-centered
+      = t('.edit')
+    .section
+      = form_with model: @user, url: user_registration_path, html: { method: :put } do |f|
+        = render 'devise/shared/error_messages', resource: resource
+        .field.devise-page-width.mx-auto.has-text-weight-semibold.is-size-6-mobile
+          = f.label :email
+          = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
+          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
             | Currently waiting confirmation for:
             = resource.unconfirmed_email
-      .field
-        .container.has-text-left.has-text-weight-semibold.my-4
+        .field.devise-page-width.mx-auto.has-text-weight-semibold.is-size-6-mobile
           = f.label :current_password
           i
-          = f.password_field :current_password, autocomplete: 'current-password', class: 'input', placeholder: t('.current')
-        .container.has-text-left.has-text-weight-semibold.my-4
+          = f.password_field :current_password, autocomplete: 'current-password', class: 'input', placeholder: 'Password'
+        .field.devise-page-width.mx-auto.has-text-weight-semibold.is-size-6-mobile
           = f.label :password
           = t('.blank_message')
           i
-          = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "#{@minimum_password_length} 文字以上入力してください"
-      - if @minimum_password_length
-        .container.has-text-left.has-text-weight-semibold.my-4
-          = f.label :password_confirmation
-          = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: "#{@minimum_password_length} 文字以上入力してください"
-
-        .actions.has-text-centered
-          = f.submit t('.update'), class: 'color-button button is-rounded is-medium has-text-white'
+          = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "New Password"
+          - if @minimum_password_length
+            .field.devise-page-width.mx-auto.has-text-weight-semibold.is-size-6-mobile
+            = f.label :password_confirmation
+            = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: "Password(confirm)"
+          .actions.has-text-centered
+            = f.submit t('.update'), class: 'color-button button is-rounded has-text-white mt-2'
   br
   .has-text-right
     = link_to 'アカウントを削除する', registration_path(resource_name), data: { confirm: t('.delete') }, method: :delete

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -19,14 +19,13 @@
           = f.label :password
           = t('.blank_message')
           i
-          = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "New Password"
+          = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: 'New Password'
           - if @minimum_password_length
             .field.devise-page-width.mx-auto.has-text-weight-semibold.is-size-6-mobile
             = f.label :password_confirmation
-            = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: "Password(confirm)"
+            = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: 'Password(confirm)'
           .actions.has-text-centered
             = f.submit t('.update'), class: 'color-button button is-rounded has-text-white mt-2'
-  br
   .has-text-right
     = link_to 'アカウントを削除する', registration_path(resource_name), data: { confirm: t('.delete') }, method: :delete
     br

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -11,7 +11,7 @@
         .field.devise-page-width.mx-auto
           = f.label :password
           - if @minimum_password_length
-            = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "Passwrd(more than #{@minimum_password_length} characters)"
+            = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "Password"
         .field.devise-page-width.mx-auto
           = f.label :password_confirmation
           = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: 'Password(confirm)'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -11,7 +11,7 @@
         .field.devise-page-width.mx-auto
           = f.label :password
           - if @minimum_password_length
-            = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: "Password"
+            = f.password_field :password, autocomplete: 'new-password', class: 'input', placeholder: 'Password'
         .field.devise-page-width.mx-auto
           = f.label :password_confirmation
           = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: 'Password(confirm)'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -6,7 +6,7 @@
       = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
         .field.field.devise-page-width.mx-auto
           = f.label :email
-          = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'E-mail'
+          = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input', placeholder: 'example@app.com'
         .field.field.devise-page-width.mx-auto
           = f.label :password
           = f.password_field :password, autocomplete: 'current-password', class: 'input', placeholder: 'Password'

--- a/spec/system/signin_and_signup_spec.rb
+++ b/spec/system/signin_and_signup_spec.rb
@@ -61,4 +61,18 @@ RSpec.describe 'devise', type: :system, js: true do
 
     expect(page).to have_content 'パスワードは6文字以上で入力してください'
   end
+
+  it 'able to transition to login page' do
+    click_on 'Sign up'
+    expect(page).to have_content 'アカウントを作成'
+    click_on 'すでにアカウントをお持ちの場合：ログイン'
+    expect(page).to have_content 'ログイン'
+  end
+
+  it 'able to transition to sign up page' do
+    click_on 'Log in'
+    expect(page).to have_content 'ログイン'
+    click_on 'アカウントを新しく作る場合はこちら'
+    expect(page).to have_content 'アカウントを作成'
+  end
 end


### PR DESCRIPTION
## 対応した issue
#280
## 対応内容・対応背景・妥協点
- レスポンシブ対応になっていなかった
## やったこと
- フォームのwidthをレスポンシブになるように修正した
- テストを追加した
- プレースホルダーの内容を修正した
## UI before / after
### before
#### アカウント作成
<img width="325" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/190037436-afbe7c55-9262-43b0-bb96-0d98b8a9ed00.png">

#### ログイン
<img width="330" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/190037461-cead6e50-3a5d-4df1-a0d6-bfe50c96ebd5.png">


#### ユーザー情報変更
<img width="322" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/190037364-f39acf3f-65e2-4207-97bc-9ef8124ab667.png">


### after
#### アカウント作成
<img width="322" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/190037670-ca134735-8ff5-4539-8f04-5fca9bc6eb8b.png">

#### ログイン
<img width="321" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/190037689-79c4a55d-f471-4f86-be57-ee48e39a768b.png">

#### ユーザー情報変更
<img width="319" alt="Football_MyTeam" src="https://user-images.githubusercontent.com/62058863/190037652-9ef8c47d-8016-47d2-bb0f-7327567c3c9e.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
