### PR TITLE
登録してあるライバルチームが視覚的にわかるようにする

### DIFF
--- a/app/javascript/components/Organism/CompetitorTeamList.vue
+++ b/app/javascript/components/Organism/CompetitorTeamList.vue
@@ -9,7 +9,7 @@
         @click="selectTeam(team)"
         v-bind:class="{
           'has-background-link-light is-selected': competitors.some(
-            (competitor) => competitor.team_id === team.id
+            (competitor) => competitor.id === team.id
           )
         }">
         <img :src="team.logo" class="image team-logo mx-auto" />


### PR DESCRIPTION
## 対応した issue
#304
## 対応内容・対応背景・妥協点
すでに登録してあるライバルチームを視覚的にわかるようにする
## やったこと
- idを正しく選択できていなかったので修正した。

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
