### PR TITLE
ライバルチームのカウント数を修正した

### DIFF
--- a/app/javascript/components/Pages/CompetitorTeamSelect.vue
+++ b/app/javascript/components/Pages/CompetitorTeamSelect.vue
@@ -191,11 +191,11 @@ export default {
     // 自分でチームを選択する
     const followTeam = (team) => {
       selectCompetitorTeams(team.id)
-      data.competitors.some((competitor) => competitor.team_id === team.id)
+      data.competitors.some((competitor) => competitor.id === team.id)
         ? (data.competitors = data.competitors.filter(
-            (competitor) => competitor.team_id !== team.id
+            (competitor) => competitor.id !== team.id
           ))
-        : data.competitors.push({ team_id: team.id })
+        : data.competitors.push({ id: team.id })
     }
 
     const selectCompetitorTeams = (team_id) => {


### PR DESCRIPTION
## 対応した issue
#306
## 対応内容・対応背景・妥協点
ライバルチームを選択するときに、登録済みのチームを選択しても登録チーム数が増えてしまう
## やったこと
api/competitorsのキー名が誤っていたので修正
idが正しいが、team_idになっていた
## やってないこと
テストをかけていない
## UI before / after
### before
[![Image from Gyazo](https://i.gyazo.com/3c9a34caf540168c5cd2053717b0fd2b.gif)](https://gyazo.com/3c9a34caf540168c5cd2053717b0fd2b)
### after
[![Image from Gyazo](https://i.gyazo.com/b48084e63691755e2afaf44d15bd9d8f.gif)](https://gyazo.com/b48084e63691755e2afaf44d15bd9d8f)
## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
