### PR TITLE
babel/coreのバージョンを変更する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
           docker-compose run web bundle exec rspec
         env:
           RAILS_ENV: test
-       - name: Jest
+      - name: Jest
         run: docker-compose run web yarn test

--- a/app/javascript/components/Pages/TeamSelect.vue
+++ b/app/javascript/components/Pages/TeamSelect.vue
@@ -48,7 +48,7 @@ export default {
         })
     }
 
-    onMounted(setCompetitors())
+    onMounted(() => setCompetitors())
 
     return {
       data

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -13,6 +13,12 @@ environment.loaders.prepend('vue', {
   ]
 })
 
+environment.loaders.append('mjs', {
+  test: /\.mjs$/,
+  include: /node_modules/,
+  type: 'javascript/auto',
+})
+
 environment.plugins.prepend(
   'Define',
   new DefinePlugin({

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
       "spec/javascript"
     ],
     "testEnvironmentOptions": {
-      "customExportConditions": ["node", "node-addons"]
+      "customExportConditions": [
+        "node",
+        "node-addons"
+      ]
     },
     "moduleFileExtensions": [
       "js",
@@ -53,9 +56,9 @@
   },
   "version": "0.1.0",
   "devDependencies": {
+    "@babel/core": "^7.22.1",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@vue/vue3-jest": "28",
-    "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "27.4.5",
     "babel-preset-es2015": "^6.24.1",
     "eslint": "^7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.3.tgz#cd502a6a0b6e37d7ad72ce7e71a7160a3ae36f7e"
   integrity sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.15.0":
+"@babel/core@^7.1.0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.15.0", "@babel/core@^7.22.1":
   version "7.22.1"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.22.1.tgz#5de51c5206f4c6f5533562838337a603c1033cfd"
   integrity sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==
@@ -2333,11 +2333,6 @@ babel-code-frame@^6.26.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
-
-babel-core@^7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
デプロイが失敗したため緊急で修正することにした。

以下エラー内容を残しておく。
```
Building fresh packages...
       Done in 20.30s.
       Compiling...
       Compilation failed:
       node:internal/process/promises:279
                   triggerUncaughtException(err, true /* fromPromise */);
                   ^
       
       Error: Cannot find package '@babel/plugin-proposal-private-methods' imported from /tmp/build_3874d670/babel-virtual-resolve-base.js
           at new NodeError (/tmp/build_3874d670/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:203:5)
           at packageResolve (/tmp/build_3874d670/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:873:9)
           at moduleResolve (/tmp/build_3874d670/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:902:20)
           at defaultResolve (/tmp/build_3874d670/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:985:15)
           at resolve (/tmp/build_3874d670/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:999:12)
           at resolve (/tmp/build_3874d670/node_modules/@babel/core/lib/config/files/import-meta-resolve.js:13:10)
           at tryImportMetaResolve (/tmp/build_3874d670/node_modules/@babel/core/lib/config/files/plugins.js:123:45)
           at resolveStandardizedNameForImport (/tmp/build_3874d670/node_modules/@babel/core/lib/config/files/plugins.js:145:19)
           at resolveStandardizedName (/tmp/build_3874d670/node_modules/@babel/core/lib/config/files/plugins.js:154:12)
           at loadPlugin (/tmp/build_3874d670/node_modules/@babel/core/lib/config/files/plugins.js:47:20)
           at loadPlugin.next (<anonymous>)
           at createDescriptor (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-descriptors.js:139:16)
           at createDescriptor.next (<anonymous>)
           at step (/tmp/build_3874d670/node_modules/gensync/index.js:261:32)
           at evaluateAsync (/tmp/build_3874d670/node_modules/gensync/index.js:291:5)
           at /tmp/build_3874d670/node_modules/gensync/index.js:44:11
           at Array.forEach (<anonymous>)
           at Function.async (/tmp/build_3874d670/node_modules/gensync/index.js:43:15)
           at Function.all (/tmp/build_3874d670/node_modules/gensync/index.js:216:13)
           at Generator.next (<anonymous>)
           at createDescriptors (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-descriptors.js:101:41)
           at createDescriptors.next (<anonymous>)
           at createPluginDescriptors (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-descriptors.js:98:17)
           at createPluginDescriptors.next (<anonymous>)
           at /tmp/build_3874d670/node_modules/@babel/core/lib/gensync-utils/functional.js:21:23
           at Generator.next (<anonymous>)
           at mergeChainOpts (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-chain.js:349:34)
           at mergeChainOpts.next (<anonymous>)
           at chainWalker (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-chain.js:316:14)
           at chainWalker.next (<anonymous>)
           at loadFileChain (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-chain.js:192:24)
           at loadFileChain.next (<anonymous>)
           at buildRootChain (/tmp/build_3874d670/node_modules/@babel/core/lib/config/config-chain.js:78:27)
           at buildRootChain.next (<anonymous>)
           at loadPrivatePartialConfig (/tmp/build_3874d670/node_modules/@babel/core/lib/config/partial.js:79:62)
           at loadPrivatePartialConfig.next (<anonymous>) {
         code: 'ERR_MODULE_NOT_FOUND'
       }
       

 !
 !     Precompiling assets failed.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```