### PR TITLE
babel/plugin-proposal-private-methodsをdepenciesに移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "testEnvironment": "jsdom"
   },
   "dependencies": {
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.0",
@@ -57,7 +58,6 @@
   "version": "0.1.0",
   "devDependencies": {
     "@babel/core": "^7.22.1",
-    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@vue/vue3-jest": "28",
     "babel-jest": "27.4.5",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
デプロイ時にbabel/plugin-proposal-private-methodsがインストールできずにエラーが出ている.
`package.json`のdevDependenciesに配置されていたこと原因だと思われる。そのため`depencies`に移動する。