### PR TITLE
webpack-dev-serverを実行できるようにする

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function (api) {
+module.exports = function(api) {
   var validEnv = ['development', 'test', 'production']
   var currentEnv = api.env()
   var isDevelopmentEnv = api.env('development')

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,24 +53,24 @@ development:
   compile: true
 
   # Reference: https://webpack.js.org/configuration/dev-server/
-  dev_server:
-    https: false
-    host: localhost
-    port: 3035
-    public: localhost:3035
-    hmr: false
-    # Inline should be set to true if using HMR
-    inline: true
-    overlay: true
-    compress: true
-    disable_host_check: true
-    use_local_ip: false
-    quiet: false
-    pretty: false
-    headers:
-      'Access-Control-Allow-Origin': '*'
-    watch_options:
-      ignored: '**/node_modules/**'
+dev_server:
+  https: false
+  host: 0.0.0.0
+  port: 3035
+  public: 0.0.0.0:3035
+  hmr: false
+  # Inline should be set to true if using HMR
+  inline: true
+  overlay: true
+  compress: true
+  disable_host_check: true
+  use_local_ip: false
+  quiet: false
+  pretty: false
+  headers:
+    'Access-Control-Allow-Origin': '*'
+  watch_options:
+    ignored: '**/node_modules/**'
 
 test:
   <<: *default

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,9 +316,9 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-proposal-private-property-in-object@^7.21.0":
-  version "7.21.10"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.10.tgz#861ab9c7d152291c47d27838867f27c560f562c4"
-  integrity sha512-3YybmT8FN4sZFXp0kTr9Gbu90wAIhC3feNung+qcRQ1wALGoSHgOz1c+fR3ZLGZ0LXqIpYmtE6Faua6tMDarUg==
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-create-class-features-plugin" "^7.21.0"
@@ -3228,9 +3228,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001489:
-  version "1.0.30001494"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz#3e56e04a48da7a79eae994559eb1ec02aaac862f"
-  integrity sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==
+  version "1.0.30001495"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz#64a0ccef1911a9dcff647115b4430f8eff1ef2d9"
+  integrity sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -4183,9 +4183,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.411:
-  version "1.4.419"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz#6fbea1f3abb65bf46e8ad874b5c1f0816ce2f8ce"
-  integrity sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw==
+  version "1.4.421"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.421.tgz#2b8c0ef98ba00d4aef4c664933d570922da52161"
+  integrity sha512-wZOyn3s/aQOtLGAwXMZfteQPN68kgls2wDAnYOA8kCjBvKVrW5RwmWVspxJYTqrcN7Y263XJVsC66VCIGzDO3g==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -9926,9 +9926,9 @@ toidentifier@1.0.1:
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tough-cookie@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
-  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
     psl "^1.1.33"
     punycode "^2.1.1"


### PR DESCRIPTION
## 対応した issue
#314 
## 対応内容・対応背景・妥協点
`bin/webpack-dev-server`を実行するとエラーが出るため修正した。

```
$ bin/webpack-dev-server
/usr/local/bundle/gems/webpacker-5.4.3/lib/webpacker/dev_server_runner.rb:38:in `initialize': getaddrinfo: Name or service not known (SocketError)
        from /usr/local/bundle/gems/webpacker-5.4.3/lib/webpacker/dev_server_runner.rb:38:in `new'
        from /usr/local/bundle/gems/webpacker-5.4.3/lib/webpacker/dev_server_runner.rb:38:in `detect_port!'
        from /usr/local/bundle/gems/webpacker-5.4.3/lib/webpacker/dev_server_runner.rb:11:in `run'
        from /usr/local/bundle/gems/webpacker-5.4.3/lib/webpacker/runner.rb:6:in `run'
        from bin/webpack-dev-server:18:in `block in <main>'
        from bin/webpack-dev-server:17:in `chdir'
        from bin/webpack-dev-server:17:in `<main>'
```

`docker-compose run webpacker bin/webpack-dev-server`で`webpack-dev-server`を実行できるようになった。
## やったこと
`webpacker.yml`のhost名を`dccker-compose.yml`の設定に合わせて修正した。
`docker-compose.yml`で`WEBPACKER_DEV_SERVER_HOST=0.0.0.0`としていたのでそれに合わせて、`webpacker.yml`のhost名を`0.0.0.0`、publicを`0.0.0.0:3035`に変更した。

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
