### PR TITLE
webpackのキャッシュを定期的に削除するコードを追加

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -51,7 +51,7 @@ default: &default
 development:
   <<: *default
   compile: true
-
+  clean: true
   # Reference: https://webpack.js.org/configuration/dev-server/
 dev_server:
   https: false


### PR DESCRIPTION
JavaScriptのファイルを読み込めなくなることが定期的に起こっていた。
その際に以下のエラーメッセージが表示される。
```
`Refused to execute script from 'http://localhost:3000/packs/js/application-ba712158178eb3082c3b.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.`
```
`public/packs`内のファイルを削除すると改善した。
`config/webpacker.yml`に`clean: true`を追加した。
