### PR TITLE
サインアップとログインのボタンのラベルを変更する

### DIFF
--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -16,6 +16,6 @@
           = f.label :password_confirmation
           = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'input', placeholder: 'Password(confirm)'
         .actions.has-text-centered
-          = f.submit 'Sign up Using Email', class: 'sign-up-using-mail color-button button is-rounded has-text-white'
+          = f.submit 'Sign up', class: 'sign-up-using-mail color-button button is-rounded has-text-white'
       .mt-4.has-text-centered
         = link_to 'すでにアカウントをお持ちの場合：ログイン', new_user_session_path

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -15,6 +15,6 @@
             = f.check_box :remember_me
             = f.label :remember_me
           .actions.has-text-centered
-            = f.submit 'Log in Using Email', class: 'color-button button is-rounded has-text-white'
+            = f.submit 'Login', class: 'color-button button is-rounded has-text-white'
       .mt-4.has-text-centered
         = link_to 'アカウントを新しく作る場合はこちら', new_user_registration_path

--- a/spec/system/favorite_team_select_spec.rb
+++ b/spec/system/favorite_team_select_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'register selected a favorite team', type: :system, js: true do
     fill_in 'Eメール', with: 'fjord2022@example.com'
     fill_in 'パスワード', with: '123456'
     fill_in 'パスワード（確認用）', with: '123456'
-    click_button 'Sign up Using Email'
+    click_button 'Sign up'
   end
 
   it 'Select one of the leagues shown. The teams belonging to the league you selected will then be displayed', js: true do

--- a/spec/system/not_found_spec.rb
+++ b/spec/system/not_found_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'NotFoundPage', type: :system, js: true do
     fill_in 'Eメール', with: 'fjord2022@example.com'
     fill_in 'パスワード', with: '123456'
     fill_in 'パスワード（確認用）', with: '123456'
-    click_button 'Sign up Using Email'
+    click_button 'Sign up'
 
     visit '/rails'
     expect(page).to have_content "404\nお探しのページが見つかりませんでした"

--- a/spec/system/signin_and_signup_spec.rb
+++ b/spec/system/signin_and_signup_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'devise', type: :system, js: true do
     click_on 'Log in'
     fill_in 'Eメール', with: user.email
     fill_in 'パスワード', with: user.password
-    click_button 'Log in Using Email'
+    click_button 'Login'
 
     expect(page).to have_content 'ログインしました'
   end
@@ -28,7 +28,7 @@ RSpec.describe 'devise', type: :system, js: true do
     click_on 'Log in'
     fill_in 'Eメール', with: 'error@example.com'
     fill_in 'パスワード', with: user.password
-    click_button 'Log in Using Email'
+    click_button 'Login'
 
     expect(page).to have_content 'Eメールまたはパスワードが違います。'
   end
@@ -37,7 +37,7 @@ RSpec.describe 'devise', type: :system, js: true do
     click_on 'Log in'
     fill_in 'Eメール', with: user.email
     fill_in 'パスワード', with: 'xxxxxx'
-    click_button 'Log in Using Email'
+    click_button 'Login'
 
     expect(page).to have_content 'Eメールまたはパスワードが違います。'
   end
@@ -47,7 +47,7 @@ RSpec.describe 'devise', type: :system, js: true do
     fill_in 'Eメール', with: 'fjord2022@example.com'
     fill_in 'パスワード', with: '123456'
     fill_in 'パスワード（確認用）', with: '123456'
-    click_button 'Sign up Using Email'
+    click_button 'Sign up'
 
     expect(page).to have_content 'アカウント登録が完了しました'
   end
@@ -57,7 +57,7 @@ RSpec.describe 'devise', type: :system, js: true do
     fill_in 'Eメール', with: 'abc@example.com'
     fill_in 'パスワード', with: '1234'
     fill_in 'パスワード（確認用）', with: '1234'
-    click_button 'Sign up Using Email'
+    click_button 'Sign up'
 
     expect(page).to have_content 'パスワードは6文字以上で入力してください'
   end


### PR DESCRIPTION
## 対応した issue
#331 
## 対応内容・対応背景・妥協点
- Sign upのラベルを変更
- Loginのラベルを変更

ボタンのラベルに文章は冗長な表現

## UI before / after
### before
<img width="658" alt="Football_MyTeam" src="https://github.com/R-Tsukada/football-myteam/assets/62058863/1ade8a43-c6f2-4e46-b891-8bd410bb23eb">

### after
<img width="608" alt="Football_MyTeam" src="https://github.com/R-Tsukada/football-myteam/assets/62058863/713d8c72-5eca-4831-b321-e000609348f6">

<img width="602" alt="Football_MyTeam" src="https://github.com/R-Tsukada/football-myteam/assets/62058863/55873ac3-d3c2-415f-b19c-39d712e20117">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the text on the registration and login buttons for clarity and consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->