### PR TITLE
シードデータの入れ替えとTeamテーブルにactiveカラムを追加

### DIFF
--- a/app/controllers/api/team_filter_controller.rb
+++ b/app/controllers/api/team_filter_controller.rb
@@ -5,6 +5,6 @@ class API::TeamFilterController < ApplicationController
 
   def index
     team = current_user.favorite.team
-    @filter = Team.where(league: team.league_id).where.not(id: team.id)
+    @filter = Team.where(league: team.league_id, active: true).where.not(id: team.id)
   end
 end

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -2,6 +2,6 @@
 
 class API::TeamsController < ApplicationController
   def index
-    @teams = Team.all
+    @teams = Team.all.where(active: true)
   end
 end

--- a/app/models/match_request.rb
+++ b/app/models/match_request.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'net/http'
+require 'openssl'
+require 'json'
+
 class MatchRequest
   def initialize
     @build_url = BuildUrl.new

--- a/app/models/standing_request.rb
+++ b/app/models/standing_request.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'net/http'
+require 'openssl'
+require 'json'
+
 class StandingRequest
   def initialize
     @build_url = BuildUrl.new

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,10 +5,11 @@ class Team < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :logo, presence: true, uniqueness: true
   validates :home_city, presence: true
+  validates :active, inclusion: { in: [true, false] }
 
   belongs_to :league
   has_one :favorite, dependent: :destroy
-  has_many :competitor, dependent: :destroy
+  has_many :competitors, dependent: :destroy
   has_one :standing, dependent: :destroy
-  has_many :match, dependent: :destroy
+  has_many :matches, dependent: :destroy
 end

--- a/db/migrate/20240804082513_add_active_to_teams.rb
+++ b/db/migrate/20240804082513_add_active_to_teams.rb
@@ -1,5 +1,5 @@
 class AddActiveToTeams < ActiveRecord::Migration[7.1]
   def change
-    add_column :teams, :active, :boolean
+    add_column :teams, :active, :boolean, default: true, null: false
   end
 end

--- a/db/migrate/20240804082513_add_active_to_teams.rb
+++ b/db/migrate/20240804082513_add_active_to_teams.rb
@@ -1,0 +1,5 @@
+class AddActiveToTeams < ActiveRecord::Migration[7.1]
+  def change
+    add_column :teams, :active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_04_082513) do
     t.string "stadium"
     t.integer "last_season_rank"
     t.string "code"
-    t.boolean "active"
+    t.boolean "active", default: true, null: false
     t.index ["api_id"], name: "index_teams_on_api_id", unique: true
     t.index ["league_id"], name: "index_teams_on_league_id"
     t.index ["logo"], name: "index_teams_on_logo", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_30_001438) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_04_082513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_001438) do
     t.string "stadium"
     t.integer "last_season_rank"
     t.string "code"
+    t.boolean "active"
     t.index ["api_id"], name: "index_teams_on_api_id", unique: true
     t.index ["league_id"], name: "index_teams_on_league_id"
     t.index ["logo"], name: "index_teams_on_logo", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,39 +1,39 @@
 # frozen_string_literal: true
 
-# League.create(
-#  [
-#    {
-#      "id": 1,
-#      "api_id": 39,
-#      "name": 'Premier',
-#      "logo": 'https://media.api-sports.io/football/leagues/39.png'
-#    },
-#    {
-#      "id": 2,
-#      "api_id": 135,
-#      "name": 'Serie A',
-#      "logo": 'https://media.api-sports.io/football/leagues/135.png'
-#    },
-#    {
-#      "id": 3,
-#      "api_id": 140,
-#      "name": 'La Liga',
-#      "logo": 'https://media.api-sports.io/football/leagues/140.png'
-#    },
-#    {
-#      "id": 4,
-#      "api_id": 78,
-#      "name": 'Bundes',
-#      "logo": 'https://media.api-sports.io/football/leagues/78.png'
-#    }
-#  ]
-# )
+League.create(
+  [
+    {
+      "id": 1,
+      "api_id": 39,
+      "name": 'Premier',
+      "logo": 'https://media.api-sports.io/football/leagues/39.png'
+    },
+    {
+      "id": 2,
+      "api_id": 135,
+      "name": 'Serie A',
+      "logo": 'https://media.api-sports.io/football/leagues/135.png'
+    },
+    {
+      "id": 3,
+      "api_id": 140,
+      "name": 'La Liga',
+      "logo": 'https://media.api-sports.io/football/leagues/140.png'
+    },
+    {
+      "id": 4,
+      "api_id": 78,
+      "name": 'Bundes',
+      "logo": 'https://media.api-sports.io/football/leagues/78.png'
+    }
+  ]
+)
 
 Team.create(
   [
     # --------- Premier ---------------
     {
-      "id": 1,
+      "id": 33,
       "name": 'Manchester United',
       "code": 'MUN',
       "logo": 'https://media.api-sports.io/football/teams/33.png',
@@ -41,10 +41,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Manchester',
       "stadium": 'Old Trafford',
-      "last_season_rank": 3
+      "last_season_rank": 8,
+      "active": true
     },
     {
-      "id": 2,
+      "id": 34,
       "name": 'Newcastle',
       "code": 'NEW',
       "logo": 'https://media.api-sports.io/football/teams/34.png',
@@ -52,21 +53,22 @@ Team.create(
       "league_id": 1,
       "home_city": 'Newcastle upon Tyne',
       "stadium": "St. James' Park",
-      "last_season_rank": 4
+      "last_season_rank": 7,
+      "active": true
     },
-    # 2021-2022降格
-    # {
-    #   "id": 3,
-    #   "name": 'Watford',
-    #   "logo": 'https://media.api-sports.io/football/teams/38.png',
-    #   "api_id": 38,
-    #   "league_id": 1,
-    #   "home_city": 'Watford',
-    #   "stadium": 'Vicarage Road',
-    #   "last_season_rank": ''
-    # },
     {
-      "id": 79,
+      "id": 38,
+      "name": 'Watford',
+      "logo": 'https://media.api-sports.io/football/teams/38.png',
+      "api_id": 38,
+      "league_id": 1,
+      "home_city": 'Watford',
+      "stadium": 'Vicarage Road',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 35,
       "name": 'Bournemouth',
       "code": 'BOU',
       "logo": 'https://media.api-sports.io/football/teams/35.png',
@@ -74,10 +76,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Bournemouth',
       "stadium": 'Vitality Stadium',
-      "last_season_rank": 15
+      "last_season_rank": 12,
+      "active": true
     },
     {
-      "id": 80,
+      "id": 36,
       "name": 'Fulham',
       "code": 'FUL',
       "logo": 'https://media.api-sports.io/football/teams/36.png',
@@ -85,10 +88,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Craven Cottage',
-      "last_season_rank": 10
+      "last_season_rank": 13,
+      "active": true
     },
     {
-      "id": 4,
+      "id": 39,
       "name": 'Wolves',
       "code": 'WOL',
       "logo": 'https://media.api-sports.io/football/teams/39.png',
@@ -96,10 +100,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Wolverhampton, West Midlands',
       "stadium": 'Molineux Stadium',
-      "last_season_rank": 13
+      "last_season_rank": 14,
+      "active": true
     },
     {
-      "id": 5,
+      "id": 40,
       "name": 'Liverpool',
       "code": 'LIV',
       "logo": 'https://media.api-sports.io/football/teams/40.png',
@@ -107,22 +112,23 @@ Team.create(
       "league_id": 1,
       "home_city": 'Liverpool',
       "stadium": 'Anfield',
-      "last_season_rank": 5
+      "last_season_rank": 3,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    # "id": 6,
-    #  "name": 'Southampton',
-    #  "code": 'SOU',
-    #  "logo": 'https://media.api-sports.io/football/teams/41.png',
-    #  "api_id": 41,
-    #  "league_id": 1,
-    #  "home_city": 'Southampton, Hampshire',
-    #  "stadium": "St. Mary's Stadium",
-    #  "last_season_rank": 15
-    # },
     {
-      "id": 7,
+      "id": 41,
+      "name": 'Southampton',
+      "code": 'SOU',
+      "logo": 'https://media.api-sports.io/football/teams/41.png',
+      "api_id": 41,
+      "league_id": 1,
+      "home_city": 'Southampton, Hampshire',
+      "stadium": "St. Mary's Stadium",
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 42,
       "name": 'Arsenal',
       "code": 'ARS',
       "logo": 'https://media.api-sports.io/football/teams/42.png',
@@ -130,20 +136,22 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Emirates Stadium',
-      "last_season_rank": 2
+      "last_season_rank": 2,
+      "active": true
     },
     {
-      "id": 8,
+      "id": 44,
       "name": 'Burnley',
       "logo": 'https://media.api-sports.io/football/teams/44.png',
       "api_id": 44,
       "league_id": 1,
       "home_city": 'Burnley',
       "stadium": 'Turf Moor',
-      "last_season_rank": 21
+      "last_season_rank": 19,
+      "active": false
     },
     {
-      "id": 9,
+      "id": 45,
       "name": 'Everton',
       "code": 'EVE',
       "logo": 'https://media.api-sports.io/football/teams/45.png',
@@ -151,21 +159,23 @@ Team.create(
       "league_id": 1,
       "home_city": 'Liverpool',
       "stadium": 'Goodison Park',
-      "last_season_rank": 17
+      "last_season_rank": 15,
+      "active": true
     },
-    # {
-    #  "id": 10,
-    #  "name": 'Leicester',
-    #  "code": 'LEI',
-    #  "logo": 'https://media.api-sports.io/football/teams/46.png',
-    #  "api_id": 46,
-    #  "league_id": 1,
-    #  "home_city": 'Leicester, Leicestershire',
-    #  "stadium": 'King Power Stadium',
-    #  "last_season_rank": 8
-    # },
     {
-      "id": 11,
+      "id": 46,
+      "name": 'Leicester',
+      "code": 'LEI',
+      "logo": 'https://media.api-sports.io/football/teams/46.png',
+      "api_id": 46,
+      "league_id": 1,
+      "home_city": 'Leicester, Leicestershire',
+      "stadium": 'King Power Stadium',
+      "last_season_rank": 8,
+      "active": true
+    },
+    {
+      "id": 47,
       "name": 'Tottenham',
       "code": 'TOT',
       "logo": 'https://media.api-sports.io/football/teams/47.png',
@@ -173,10 +183,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Tottenham Hotspur Stadium',
-      "last_season_rank": 8
+      "last_season_rank": 5,
+      "active": true
     },
     {
-      "id": 12,
+      "id": 48,
       "name": 'West Ham',
       "code": 'WES',
       "logo": 'https://media.api-sports.io/football/teams/48.png',
@@ -184,10 +195,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'London Stadium',
-      "last_season_rank": 14
+      "last_season_rank": 9,
+      "active": true
     },
     {
-      "id": 13,
+      "id": 49,
       "name": 'Chelsea',
       "code": 'CHE',
       "logo": 'https://media.api-sports.io/football/teams/49.png',
@@ -195,10 +207,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Stamford Bridge',
-      "last_season_rank": 12
+      "last_season_rank": 6,
+      "active": true
     },
     {
-      "id": 14,
+      "id": 50,
       "name": 'Manchester City',
       "code": 'MAC',
       "logo": 'https://media.api-sports.io/football/teams/50.png',
@@ -206,10 +219,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Manchester',
       "stadium": 'Etihad Stadium',
-      "last_season_rank": 1
+      "last_season_rank": 1,
+      "active": true
     },
     {
-      "id": 15,
+      "id": 51,
       "name": 'Brighton',
       "code": 'BRI',
       "logo": 'https://media.api-sports.io/football/teams/51.png',
@@ -217,10 +231,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Falmer, East Sussex',
       "stadium": 'The American Express Community Stadium',
-      "last_season_rank": 6
+      "last_season_rank": 11,
+      "active": true
     },
     {
-      "id": 16,
+      "id": 52,
       "name": 'Crystal Palace',
       "code": 'CRY',
       "logo": 'https://media.api-sports.io/football/teams/52.png',
@@ -228,10 +243,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Selhurst Park',
-      "last_season_rank": 11
+      "last_season_rank": 10,
+      "active": true
     },
     {
-      "id": 17,
+      "id": 55,
       "name": 'Brentford',
       "code": 'BRE',
       "logo": 'https://media.api-sports.io/football/teams/55.png',
@@ -239,22 +255,35 @@ Team.create(
       "league_id": 1,
       "home_city": 'London',
       "stadium": 'Brentford Community Stadium',
-      "last_season_rank": 9
+      "last_season_rank": 16,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    # "id": 18,
-    # "name": 'Leeds',
-    # "code": 'LEE',
-    # "logo": 'https://media.api-sports.io/football/teams/63.png',
-    # "api_id": 63,
-    # "league_id": 1,
-    # "home_city": 'Leeds',
-    # "stadium": 'Elland Road',
-    # "last_season_rank": 17
-    # },
     {
-      "id": 81,
+      "id": 63,
+      "name": 'Leeds',
+      "code": 'LEE',
+      "logo": 'https://media.api-sports.io/football/teams/63.png',
+      "api_id": 63,
+      "league_id": 1,
+      "home_city": 'Leeds',
+      "stadium": 'Elland Road',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 57,
+      "name": 'Ipswich',
+      "code": 'IPS',
+      "logo": 'https://media.api-sports.io/football/teams/57.png',
+      "api_id": 57,
+      "league_id": 1,
+      "home_city": 'Ipswich',
+      "stadium": 'Portman Road',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 65,
       "name": 'Nottm Forest',
       "code": 'NOT',
       "logo": 'https://media.api-sports.io/football/teams/65.png',
@@ -262,10 +291,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Nottingham',
       "stadium": 'The City Ground',
-      "last_season_rank": 16
+      "last_season_rank": 16,
+      "active": true
     },
     {
-      "id": 19,
+      "id": 66,
       "name": 'Aston Villa',
       "code": 'AST',
       "logo": 'https://media.api-sports.io/football/teams/66.png',
@@ -273,10 +303,11 @@ Team.create(
       "league_id": 1,
       "home_city": 'Birmingham',
       "stadium": 'Villa Park',
-      "last_season_rank": 7
+      "last_season_rank": 4,
+      "active": true
     },
     {
-      "id": 88,
+      "id": 62,
       "name": 'Sheffield Utd',
       "code": 'SHE',
       "logo": 'https://media-4.api-sports.io/football/teams/62.png',
@@ -284,7 +315,8 @@ Team.create(
       "league_id": 1,
       "home_city": 'Sheffield',
       "stadium": 'Bramall Lane',
-      "last_season_rank": 22
+      "last_season_rank": 20,
+      "active": false
     },
     {
       "id": 1359,
@@ -295,22 +327,23 @@ Team.create(
       "league_id": 1,
       "home_city": 'Luton',
       "stadium": 'Kenilworth Road',
-      "last_season_rank": 23
+      "last_season_rank": 18,
+      "active": false
     },
-    # 2021-2022降格
-    # {
-    #   "id": 20,
-    #   "name": 'Norwich',
-    #   "logo": 'https://media.api-sports.io/football/teams/71.png',
-    #   "api_id": 71,
-    #   "league_id": 1,
-    #   "home_city": 'Norwich, Norfolk',
-    #   "stadium": 'Carrow Road',
-    #   "last_season_rank": ''
-    # },
+    {
+      "id": 71,
+      "name": 'Norwich',
+      "logo": 'https://media.api-sports.io/football/teams/71.png',
+      "api_id": 71,
+      "league_id": 1,
+      "home_city": 'Norwich, Norfolk',
+      "stadium": 'Carrow Road',
+      "last_season_rank": '',
+      "active": false
+    },
     # --------- SelieA ---------------
     {
-      "id": 21,
+      "id": 487,
       "name": 'Lazio',
       "code": 'LAZ',
       "logo": 'https://media.api-sports.io/football/teams/487.png',
@@ -318,10 +351,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Roma',
       "stadium": 'Stadio Olimpico',
-      "last_season_rank": 2
+      "last_season_rank": 7,
+      "active": true
     },
     {
-      "id": 22,
+      "id": 488,
       "name": 'Sassuolo',
       "code": 'SAS',
       "logo": 'https://media.api-sports.io/football/teams/488.png',
@@ -329,10 +363,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Reggio nell&apos;Emilia',
       "stadium": 'MAPEI Stadium - Città del Tricolore',
-      "last_season_rank": 13
+      "last_season_rank": 19,
+      "active": false
     },
     {
-      "id": 23,
+      "id": 489,
       "name": 'AC Milan',
       "code": 'MIL',
       "logo": 'https://media.api-sports.io/football/teams/489.png',
@@ -340,20 +375,22 @@ Team.create(
       "league_id": 2,
       "home_city": 'Milano',
       "stadium": 'Stadio Giuseppe Meazza',
-      "last_season_rank": 4
+      "last_season_rank": 2,
+      "active": true
     },
     {
-      "id": 24,
+      "id": 490,
       "name": 'Cagliari',
       "logo": 'https://media.api-sports.io/football/teams/490.png',
       "api_id": 490,
       "league_id": 2,
       "home_city": 'Cagliari',
       "stadium": 'Unipol Domus',
-      "last_season_rank": 23
+      "last_season_rank": 16,
+      "active": true
     },
     {
-      "id": 25,
+      "id": 492,
       "name": 'Napoli',
       "code": 'NAP',
       "logo": 'https://media.api-sports.io/football/teams/492.png',
@@ -361,10 +398,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Napoli',
       "stadium": 'Stadio Diego Armando Maradona',
-      "last_season_rank": 1
+      "last_season_rank": 10,
+      "active": true
     },
     {
-      "id": 26,
+      "id": 494,
       "name": 'Udinese',
       "code": 'UDI',
       "logo": 'https://media.api-sports.io/football/teams/494.png',
@@ -372,20 +410,22 @@ Team.create(
       "league_id": 2,
       "home_city": 'Udine',
       "stadium": 'Dacia Arena',
-      "last_season_rank": 12
+      "last_season_rank": 15,
+      "active": true
     },
     {
-      "id": 27,
+      "id": 495,
       "name": 'Genoa',
       "logo": 'https://media.api-sports.io/football/teams/495.png',
       "api_id": 495,
       "league_id": 2,
       "home_city": 'Genova',
       "stadium": 'Stadio Comunale Luigi Ferraris',
-      "last_season_rank": 22
+      "last_season_rank": 11,
+      "active": true
     },
     {
-      "id": 28,
+      "id": 496,
       "name": 'Juventus',
       "code": 'JUV',
       "logo": 'https://media.api-sports.io/football/teams/496.png',
@@ -393,10 +433,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Torino',
       "stadium": 'Allianz Stadium',
-      "last_season_rank": 7
+      "last_season_rank": 3,
+      "active": true
     },
     {
-      "id": 29,
+      "id": 497,
       "name": 'AS Roma',
       "code": 'ROM',
       "logo": 'https://media.api-sports.io/football/teams/497.png',
@@ -404,22 +445,23 @@ Team.create(
       "league_id": 2,
       "home_city": 'Roma',
       "stadium": 'Stadio Olimpico',
-      "last_season_rank": 6
+      "last_season_rank": 6,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    #  "id": 30,
-    #  "name": 'Sampdoria',
-    #  "code": 'SAM',
-    #  "logo": 'https://media.api-sports.io/football/teams/498.png',
-    #  "api_id": 498,
-    #  "league_id": 2,
-    #  "home_city": 'Genova',
-    #  "stadium": 'Stadio Comunale Luigi Ferraris',
-    #  "last_season_rank": 15
-    # },
     {
-      "id": 31,
+      "id": 498,
+      "name": 'Sampdoria',
+      "code": 'SAM',
+      "logo": 'https://media.api-sports.io/football/teams/498.png',
+      "api_id": 498,
+      "league_id": 2,
+      "home_city": 'Genova',
+      "stadium": 'Stadio Comunale Luigi Ferraris',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 499,
       "name": 'Atalanta',
       "code": 'ATA',
       "logo": 'https://media.api-sports.io/football/teams/499.png',
@@ -427,10 +469,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Bergamo',
       "stadium": 'Gewiss Stadium',
-      "last_season_rank": 5
+      "last_season_rank": 4,
+      "active": true
     },
     {
-      "id": 32,
+      "id": 500,
       "name": 'Bologna',
       "code": 'BOL',
       "logo": 'https://media.api-sports.io/football/teams/500.png',
@@ -438,10 +481,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Bologna',
       "stadium": "Stadio Renato Dall'Ara",
-      "last_season_rank": 9
+      "last_season_rank": 5,
+      "active": true
     },
     {
-      "id": 33,
+      "id": 502,
       "name": 'Fiorentina',
       "code": 'FIO',
       "logo": 'https://media.api-sports.io/football/teams/502.png',
@@ -449,10 +493,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Firenze',
       "stadium": 'Stadio Artemio Franchi',
-      "last_season_rank": 8
+      "last_season_rank": 8,
+      "active": true
     },
     {
-      "id": 34,
+      "id": 503,
       "name": 'Torino',
       "code": 'TOR',
       "logo": 'https://media.api-sports.io/football/teams/503.png',
@@ -460,10 +505,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Torino',
       "stadium": 'Stadio Olimpico Grande Torino',
-      "last_season_rank": 10
+      "last_season_rank": 9,
+      "active": true
     },
     {
-      "id": 35,
+      "id": 504,
       "name": 'Verona',
       "code": 'VER',
       "logo": 'https://media.api-sports.io/football/teams/504.png',
@@ -471,10 +517,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Verona',
       "stadium": "Stadio Marc'Antonio Bentegodi",
-      "last_season_rank": 18
+      "last_season_rank": 13,
+      "active": true
     },
     {
-      "id": 36,
+      "id": 505,
       "name": 'Inter',
       "code": 'INT',
       "logo": 'https://media.api-sports.io/football/teams/505.png',
@@ -482,10 +529,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Milano',
       "stadium": 'Stadio Giuseppe Meazza',
-      "last_season_rank": 3
+      "last_season_rank": 1,
+      "active": true
     },
     {
-      "id": 37,
+      "id": 511,
       "name": 'Empoli',
       "code": 'EMP',
       "logo": 'https://media.api-sports.io/football/teams/511.png',
@@ -493,10 +541,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Empoli',
       "stadium": 'Stadio Carlo Castellani',
-      "last_season_rank": 14
+      "last_season_rank": 17,
+      "active": true
     },
     {
-      "id": 90,
+      "id": 512,
       "name": 'Frosinone',
       "code": 'FRO',
       "logo": 'https://media-4.api-sports.io/football/teams/512.png',
@@ -504,10 +553,11 @@ Team.create(
       "league_id": 2,
       "home_city": 'Frosinone',
       "stadium": 'Stadio Benito Stirpe',
-      "last_season_rank": 21
+      "last_season_rank": 18,
+      "active": false
     },
     {
-      "id": 38,
+      "id": 514,
       "name": 'Salernitana',
       "code": 'SAL',
       "logo": 'https://media.api-sports.io/football/teams/514.png',
@@ -515,45 +565,58 @@ Team.create(
       "league_id": 2,
       "home_city": 'Salerno',
       "stadium": 'Stadio Arechi',
-      "last_season_rank": 15
+      "last_season_rank": 20,
+      "active": false
     },
-    # 2022-2023降格
-    # {
-    #  "id": 39,
-    #  "name": 'Spezia',
-    #  "code": 'SPE',
-    #  "logo": 'https://media.api-sports.io/football/teams/515.png',
-    #  "api_id": 515,
-    #  "league_id": 2,
-    #  "home_city": 'La Spezia',
-    #  "stadium": 'Stadio Alberto Picco',
-    #  "last_season_rank": 16
-    # },
-    # 2021-2022降格
-    # {
-    #   "id": 40,
-    #   "name": 'Venezia',
-    #   "logo": 'https://media.api-sports.io/football/teams/517.png',
-    #   "api_id": 517,
-    #   "league_id": 2,
-    #   "home_city": 'Venezia',
-    #   "stadium": 'Stadio Pierluigi Penzo',
-    #   "last_season_rank": ''
-    # },
-    # 2022-2023降格
-    # {
-    # "id": 82,
-    #  "name": 'Cremonese',
-    #  "code": 'CRE',
-    #  "logo": 'https://media.api-sports.io/football/teams/520.png',
-    #  "api_id": 520,
-    #  "league_id": 2,
-    #  "home_city": 'Cremona',
-    #  "stadium": 'Stadio Giovanni Zini',
-    #  "last_season_rank": ''
-    # },
     {
-      "id": 83,
+      "id": 515,
+      "name": 'Spezia',
+      "code": 'SPE',
+      "logo": 'https://media.api-sports.io/football/teams/515.png',
+      "api_id": 515,
+      "league_id": 2,
+      "home_city": 'La Spezia',
+      "stadium": 'Stadio Alberto Picco',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 517,
+      "name": 'Venezia',
+      "logo": 'https://media.api-sports.io/football/teams/517.png',
+      "api_id": 517,
+      "league_id": 2,
+      "home_city": 'Venezia',
+      "stadium": 'Stadio Pierluigi Penzo',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 520,
+      "name": 'Cremonese',
+      "code": 'CRE',
+      "logo": 'https://media.api-sports.io/football/teams/520.png',
+      "api_id": 520,
+      "league_id": 2,
+      "home_city": 'Cremona',
+      "stadium": 'Stadio Giovanni Zini',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 523,
+      "name": 'Parma',
+      "code": 'PAR',
+      "logo": 'https://media.api-sports.io/football/teams/523.png',
+      "api_id": 523,
+      "league_id": 2,
+      "home_city": 'Parma',
+      "stadium": 'Stadio Ennio Tardini',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 867,
       "name": 'Lecce',
       "code": 'LEC',
       "logo": 'https://media.api-sports.io/football/teams/867.png',
@@ -561,10 +624,23 @@ Team.create(
       "league_id": 2,
       "home_city": 'Lecce',
       "stadium": 'Stadio Comunale Via del Mare',
-      "last_season_rank": 16
+      "last_season_rank": 14,
+      "active": true
     },
     {
-      "id": 84,
+      "id": 892,
+      "name": 'Como',
+      "code": 'COM',
+      "logo": 'https://media.api-sports.io/football/teams/892.png',
+      "api_id": 892,
+      "league_id": 2,
+      "home_city": 'Como',
+      "stadium": 'Stadio Giuseppe Sinigaglia',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 1579,
       "name": 'Monza',
       "code": 'MON',
       "logo": 'https://media.api-sports.io/football/teams/1579.png',
@@ -572,11 +648,12 @@ Team.create(
       "league_id": 2,
       "home_city": 'Monza',
       "stadium": 'U-Power Stadium',
-      "last_season_rank": 11
+      "last_season_rank": 12,
+      "active": true
     },
     # --------- LaLiga ---------------
     {
-      "id": 41,
+      "id": 529,
       "name": 'Barcelona',
       "code": 'BAR',
       "logo": 'https://media.api-sports.io/football/teams/529.png',
@@ -584,10 +661,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Barcelona',
       "stadium": 'Camp Nou',
-      "last_season_rank": 1
+      "last_season_rank": 2,
+      "active": true
     },
     {
-      "id": 42,
+      "id": 530,
       "name": 'Atletico Madrid',
       "code": 'MAD',
       "logo": 'https://media.api-sports.io/football/teams/530.png',
@@ -595,10 +673,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Madrid',
       "stadium": 'Estadio Wanda Metropolitano',
-      "last_season_rank": 3
+      "last_season_rank": 4,
+      "active": true
     },
     {
-      "id": 43,
+      "id": 531,
       "name": 'Athletic Club',
       "code": 'BIL',
       "logo": 'https://media.api-sports.io/football/teams/531.png',
@@ -606,10 +685,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Bilbao',
       "stadium": 'San Mamés Barria',
-      "last_season_rank": 8
+      "last_season_rank": 5,
+      "active": true
     },
     {
-      "id": 44,
+      "id": 532,
       "name": 'Valencia',
       "code": 'VAL',
       "logo": 'https://media.api-sports.io/football/teams/532.png',
@@ -617,10 +697,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Valencia',
       "stadium": 'Estadio de Mestalla',
-      "last_season_rank": 16
+      "last_season_rank": 9,
+      "active": true
     },
     {
-      "id": 45,
+      "id": 533,
       "name": 'Villarreal',
       "code": 'VIL',
       "logo": 'https://media.api-sports.io/football/teams/533.png',
@@ -628,7 +709,8 @@ Team.create(
       "league_id": 3,
       "home_city": 'Villarreal',
       "stadium": 'Estadio de la Cerámica',
-      "last_season_rank": 5
+      "last_season_rank": 8,
+      "active": true
     },
     {
       "id": 534,
@@ -639,10 +721,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Las Palmas de Gran Canaria',
       "stadium": 'Estadio de Gran Canaria',
-      "last_season_rank": 22
+      "last_season_rank": 15,
+      "active": true
     },
     {
-      "id": 46,
+      "id": 536,
       "name": 'Sevilla',
       "code": 'SEV',
       "logo": 'https://media.api-sports.io/football/teams/536.png',
@@ -650,10 +733,23 @@ Team.create(
       "league_id": 3,
       "home_city": 'Sevilla',
       "stadium": 'Estadio Ramón Sánchez Pizjuán',
-      "last_season_rank": 12
+      "last_season_rank": 13,
+      "active": true
     },
     {
-      "id": 47,
+      "id": 537,
+      "name": 'Leganes',
+      "code": 'LEG',
+      "logo": 'https://media.api-sports.io/football/teams/537.png',
+      "api_id": 537,
+      "league_id": 3,
+      "home_city": 'Leganés',
+      "stadium": 'Estadio Municipal de Butarque',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 538,
       "name": 'Celta Vigo',
       "code": 'CEL',
       "logo": 'https://media.api-sports.io/football/teams/538.png',
@@ -661,33 +757,34 @@ Team.create(
       "league_id": 3,
       "home_city": 'Vigo',
       "stadium": 'Abanca-Balaídos',
-      "last_season_rank": 13
+      "last_season_rank": 14,
+      "active": true
     },
-    # 2021-2022降格
-    # {
-    #   "id": 48,
-    #   "name": 'Levante',
-    #   "logo": 'https://media.api-sports.io/football/teams/539.png',
-    #   "api_id": 539,
-    #   "league_id": 3,
-    #   "home_city": 'Valencia',
-    #   "stadium": 'Estadio Ciudad de Valencia',
-    #   "last_season_rank": 14
-    # },
-    # 2022-2023降格
-    # {
-    #  "id": 49,
-    #  "name": 'Espanyol',
-    #  "code": 'ESP',
-    #  "logo": 'https://media.api-sports.io/football/teams/540.png',
-    #  "api_id": 540,
-    #  "league_id": 3,
-    #  "home_city": 'Cornella de Llobregat',
-    #  "stadium": 'RCDE Stadium',
-    #  "last_season_rank": 14
-    # },
     {
-      "id": 50,
+      "id": 539,
+      "name": 'Levante',
+      "logo": 'https://media.api-sports.io/football/teams/539.png',
+      "api_id": 539,
+      "league_id": 3,
+      "home_city": 'Valencia',
+      "stadium": 'Estadio Ciudad de Valencia',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 540,
+      "name": 'Espanyol',
+      "code": 'ESP',
+      "logo": 'https://media.api-sports.io/football/teams/540.png',
+      "api_id": 540,
+      "league_id": 3,
+      "home_city": 'Cornella de Llobregat',
+      "stadium": 'RCDE Stadium',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 541,
       "name": 'Real Madrid',
       "code": 'REA',
       "logo": 'https://media.api-sports.io/football/teams/541.png',
@@ -695,20 +792,22 @@ Team.create(
       "league_id": 3,
       "home_city": 'Madrid',
       "stadium": 'Estadio Santiago Bernabéu',
-      "last_season_rank": 2
+      "last_season_rank": 1,
+      "active": true
     },
     {
-      "id": 51,
+      "id": 542,
       "name": 'Alaves',
       "logo": 'https://media.api-sports.io/football/teams/542.png',
       "api_id": 542,
       "league_id": 3,
       "home_city": 'Vitoria-Gasteiz',
       "stadium": 'Estadio de Mendizorroza',
-      "last_season_rank": 22
+      "last_season_rank": 10,
+      "active": true
     },
     {
-      "id": 52,
+      "id": 543,
       "name": 'Real Betis',
       "code": 'BET',
       "logo": 'https://media.api-sports.io/football/teams/543.png',
@@ -716,10 +815,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Sevilla',
       "stadium": 'Estadio Benito Villamarín',
-      "last_season_rank": 6
+      "last_season_rank": 7,
+      "active": true
     },
     {
-      "id": 53,
+      "id": 546,
       "name": 'Getafe',
       "code": 'GET',
       "logo": 'https://media.api-sports.io/football/teams/546.png',
@@ -727,7 +827,8 @@ Team.create(
       "league_id": 3,
       "home_city": 'Getafe',
       "stadium": 'Coliseum Alfonso Pérez',
-      "last_season_rank": 15
+      "last_season_rank": 12,
+      "active": true
     },
     {
       "id": 547,
@@ -738,10 +839,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Girona',
       "stadium": 'Estadi Municipal de Montilivi',
-      "last_season_rank": 10
+      "last_season_rank": 3,
+      "active": true
     },
     {
-      "id": 54,
+      "id": 548,
       "name": 'Real Sociedad',
       "code": 'RSO',
       "logo": 'https://media.api-sports.io/football/teams/548.png',
@@ -749,22 +851,34 @@ Team.create(
       "league_id": 3,
       "home_city": 'Donostia-San Sebastián',
       "stadium": 'Reale Arena',
-      "last_season_rank": 4
+      "last_season_rank": 6,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    # "id": 85,
-    # "name": 'Valladolid',
-    # "code": 'VAL',
-    # "logo": 'https://media.api-sports.io/football/teams/720.png',
-    # "api_id": 720,
-    # "league_id": 3,
-    # "home_city": 'Avenida del Mundial 82',
-    # "stadium": 'Estadio Municipal José Zorrilla',
-    # "last_season_rank": ''
-    # },
     {
-      "id": 86,
+      "id": 715,
+      "name": 'Granada CF',
+      "logo": 'https://media.api-sports.io/football/teams/715.png',
+      "api_id": 715,
+      "league_id": 3,
+      "home_city": 'Granada',
+      "stadium": 'Estadio Nuevo Los Cármenes',
+      "last_season_rank": 19,
+      "active": false
+    },
+    {
+      "id": 720,
+      "name": 'Valladolid',
+      "code": 'VAL',
+      "logo": 'https://media.api-sports.io/football/teams/720.png',
+      "api_id": 720,
+      "league_id": 3,
+      "home_city": 'Avenida del Mundial 82',
+      "stadium": 'Estadio Municipal José Zorrilla',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 723,
       "name": 'Almeria',
       "code": 'ALM',
       "logo": 'https://media.api-sports.io/football/teams/723.png',
@@ -772,20 +886,12 @@ Team.create(
       "league_id": 3,
       "home_city": 'Calle de Belladona',
       "stadium": 'Estadio de los Juegos Mediterráneos',
-      "last_season_rank": 17
+      "last_season_rank": 20,
+      "active": false
     },
+
     {
-      "id": 55,
-      "name": 'Granada CF',
-      "logo": 'https://media.api-sports.io/football/teams/715.png',
-      "api_id": 715,
-      "league_id": 3,
-      "home_city": 'Granada',
-      "stadium": 'Estadio Nuevo Los Cármenes',
-      "last_season_rank": 21
-    },
-    {
-      "id": 56,
+      "id": 724,
       "name": 'Cadiz',
       "code": 'CAD',
       "logo": 'https://media.api-sports.io/football/teams/724.png',
@@ -793,10 +899,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Cádiz',
       "stadium": 'Estadio Nuevo Mirandilla',
-      "last_season_rank": 14
+      "last_season_rank": 18,
+      "active": false
     },
     {
-      "id": 57,
+      "id": 727,
       "name": 'Osasuna',
       "code": 'OSA',
       "logo": 'https://media.api-sports.io/football/teams/727.png',
@@ -804,10 +911,11 @@ Team.create(
       "league_id": 3,
       "home_city": 'Iruñea',
       "stadium": 'Estadio El Sadar',
-      "last_season_rank": 7
+      "last_season_rank": 11,
+      "active": true
     },
     {
-      "id": 58,
+      "id": 728,
       "name": 'Rayo Vallecano',
       "code": 'RAY',
       "logo": 'https://media.api-sports.io/football/teams/728.png',
@@ -815,22 +923,23 @@ Team.create(
       "league_id": 3,
       "stadium": 'Estadio de Vallecas',
       "home_city": 'Madrid',
-      "last_season_rank": 11
+      "last_season_rank": 16,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    #  "id": 59,
-    #  "name": 'Elche',
-    #  "code": 'ELC',
-    #  "logo": 'https://media.api-sports.io/football/teams/797.png',
-    #  "api_id": 797,
-    #  "league_id": 3,
-    #  "home_city": 'Elche',
-    #  "stadium": 'Estadio Manuel Martínez Valero',
-    #  "last_season_rank": 13
-    # },
     {
-      "id": 60,
+      "id": 797,
+      "name": 'Elche',
+      "code": 'ELC',
+      "logo": 'https://media.api-sports.io/football/teams/797.png',
+      "api_id": 797,
+      "league_id": 3,
+      "home_city": 'Elche',
+      "stadium": 'Estadio Manuel Martínez Valero',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 798,
       "name": 'Mallorca',
       "code": 'MAL',
       "logo": 'https://media.api-sports.io/football/teams/798.png',
@@ -838,11 +947,12 @@ Team.create(
       "league_id": 3,
       "home_city": 'Palma de Mallorca',
       "stadium": 'Visit Mallorca Estadi',
-      "last_season_rank": 9
+      "last_season_rank": 17,
+      "active": true
     },
     # --------- Bundes ---------------
     {
-      "id": 61,
+      "id": 157,
       "name": 'Bayern Munich',
       "code": 'BAY',
       "logo": 'https://media.api-sports.io/football/teams/157.png',
@@ -850,22 +960,23 @@ Team.create(
       "league_id": 4,
       "home_city": 'München',
       "stadium": 'Allianz Arena',
-      "last_season_rank": 1
+      "last_season_rank": 3,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    #  "id": 62,
-    #  "name": 'Hertha Berlin',
-    #  "code": 'HER',
-    #  "logo": 'https://media.api-sports.io/football/teams/159.png',
-    #  "api_id": 159,
-    #  "league_id": 4,
-    #  "home_city": 'Berlin',
-    #  "stadium": 'Olympiastadion Berlin',
-    #  "last_season_rank": 16
-    # },
     {
-      "id": 63,
+      "id": 159,
+      "name": 'Hertha Berlin',
+      "code": 'HER',
+      "logo": 'https://media.api-sports.io/football/teams/159.png',
+      "api_id": 159,
+      "league_id": 4,
+      "home_city": 'Berlin',
+      "stadium": 'Olympiastadion Berlin',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 160,
       "name": 'SC Freiburg',
       "code": 'FRE',
       "logo": 'https://media.api-sports.io/football/teams/160.png',
@@ -873,10 +984,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Freiburg im Breisgau',
       "stadium": 'Europa-Park Stadion',
-      "last_season_rank": 5
+      "last_season_rank": 10,
+      "active": true
     },
     {
-      "id": 64,
+      "id": 161,
       "name": 'VfL Wolfsburg',
       "code": 'WOL',
       "logo": 'https://media.api-sports.io/football/teams/161.png',
@@ -884,10 +996,11 @@ Team.create(
       "league_id": 4,
       "stadium": 'VOLKSWAGEN ARENA',
       "home_city": 'Wolfsburg',
-      "last_season_rank": 8
+      "last_season_rank": 12,
+      "active": true
     },
     {
-      "id": 87,
+      "id": 162,
       "name": 'Werder Bremen',
       "code": 'WER',
       "logo": 'https://media.api-sports.io/football/teams/162.png',
@@ -895,10 +1008,11 @@ Team.create(
       "league_id": 4,
       "stadium": 'wohninvest WESERSTADION',
       "home_city": 'Bremen',
-      "last_season_rank": 13
+      "last_season_rank": 15,
+      "active": true
     },
     {
-      "id": 65,
+      "id": 163,
       "name": 'Borussia Monchengladbach',
       "code": 'MOE',
       "logo": 'https://media.api-sports.io/football/teams/163.png',
@@ -906,10 +1020,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Mönchengladbach',
       "stadium": 'Stadion im BORUSSIA-PARK',
-      "last_season_rank": 10
+      "last_season_rank": 14,
+      "active": true
     },
     {
-      "id": 66,
+      "id": 164,
       "name": 'FSV Mainz 05',
       "code": 'MAI',
       "logo": 'https://media.api-sports.io/football/teams/164.png',
@@ -917,10 +1032,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Mainz',
       "stadium": 'MEWA ARENA',
-      "last_season_rank": 9
+      "last_season_rank": 13,
+      "active": true
     },
     {
-      "id": 67,
+      "id": 165,
       "name": 'Borussia Dortmund',
       "code": 'DOR',
       "logo": 'https://media.api-sports.io/football/teams/165.png',
@@ -928,10 +1044,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Dortmund',
       "stadium": 'Signal-Iduna-Park',
-      "last_season_rank": 2
+      "last_season_rank": 5,
+      "active": true
     },
     {
-      "id": 68,
+      "id": 167,
       "name": '1899 Hoffenheim',
       "code": 'HOF',
       "logo": 'https://media.api-sports.io/football/teams/167.png',
@@ -939,10 +1056,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Sinsheim',
       "stadium": 'PreZero Arena',
-      "last_season_rank": 12
+      "last_season_rank": 7,
+      "active": true
     },
     {
-      "id": 69,
+      "id": 168,
       "name": 'Bayer Leverkusen',
       "code": 'BAY',
       "logo": 'https://media.api-sports.io/football/teams/168.png',
@@ -950,10 +1068,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Leverkusen',
       "stadium": 'BayArena',
-      "last_season_rank": 6
+      "last_season_rank": 1,
+      "active": true
     },
     {
-      "id": 70,
+      "id": 169,
       "name": 'Eintracht Frankfurt',
       "code": 'EIN',
       "logo": 'https://media.api-sports.io/football/teams/169.png',
@@ -961,10 +1080,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Frankfurt am Main',
       "stadium": 'Deutsche Bank Park',
-      "last_season_rank": 7
+      "last_season_rank": 6,
+      "active": true
     },
     {
-      "id": 71,
+      "id": 170,
       "name": 'FC Augsburg',
       "code": 'AUG',
       "logo": 'https://media.api-sports.io/football/teams/170.png',
@@ -972,10 +1092,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Augsburg',
       "stadium": 'WWK Arena',
-      "last_season_rank": 15
+      "last_season_rank": 11,
+      "active": true
     },
     {
-      "id": 72,
+      "id": 172,
       "name": 'VfB Stuttgart',
       "code": 'STU',
       "logo": 'https://media.api-sports.io/football/teams/172.png',
@@ -983,10 +1104,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Stuttgart',
       "stadium": 'Mercedes-Benz-Arena',
-      "last_season_rank": 16
+      "last_season_rank": 2,
+      "active": true
     },
     {
-      "id": 73,
+      "id": 173,
       "name": 'RB Leipzig',
       "code": 'LEI',
       "logo": 'https://media.api-sports.io/football/teams/173.png',
@@ -994,22 +1116,23 @@ Team.create(
       "league_id": 4,
       "home_city": 'Leipzig',
       "stadium": 'Red Bull Arena',
-      "last_season_rank": 3
+      "last_season_rank": 4,
+      "active": true
     },
-    # 2022-2023降格
-    # {
-    #  "id": 88,
-    #  "name": 'FC Schalke 04',
-    #  "code": 'SCH',
-    #  "logo": 'https://media.api-sports.io/football/teams/174.png',
-    #  "api_id": 174,
-    #  "league_id": 4,
-    #  "home_city": 'Gelsenkirchen',
-    #  "stadium": 'VELTINS-Arena',
-    #  "last_season_rank": ''
-    # },
     {
-      "id": 74,
+      "id": 174,
+      "name": 'FC Schalke 04',
+      "code": 'SCH',
+      "logo": 'https://media.api-sports.io/football/teams/174.png',
+      "api_id": 174,
+      "league_id": 4,
+      "home_city": 'Gelsenkirchen',
+      "stadium": 'VELTINS-Arena',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 176,
       "name": 'VfL BOCHUM',
       "code": 'BOC',
       "logo": 'https://media.api-sports.io/football/teams/176.png',
@@ -1017,7 +1140,19 @@ Team.create(
       "league_id": 4,
       "home_city": 'Bochum',
       "stadium": 'Vonovia Ruhrstadion',
-      "last_season_rank": 8
+      "last_season_rank": 16,
+      "active": true
+    },
+    {
+      "id": 178,
+      "name": 'SpVgg Greuther Furth',
+      "logo": 'https://media.api-sports.io/football/teams/178.png',
+      "api_id": 178,
+      "league_id": 4,
+      "home_city": 'Fürth',
+      "stadium": 'Sportpark Ronhof Thomas Sommer',
+      "last_season_rank": '',
+      "active": false
     },
     {
       "id": 180,
@@ -1028,7 +1163,8 @@ Team.create(
       "league_id": 4,
       "home_city": 'Heidenheim an der Brenz',
       "stadium": 'Voith-Arena',
-      "last_season_rank": 19
+      "last_season_rank": 8,
+      "active": true
     },
     {
       "id": 181,
@@ -1039,21 +1175,11 @@ Team.create(
       "league_id": 4,
       "home_city": 'Darmstadt',
       "stadium": 'Merck-Stadion am Böllenfalltor',
-      "last_season_rank": 20
+      "last_season_rank": '',
+      "active": false
     },
-    # 2021-2022降格
-    # {
-    #   "id": 75,
-    #   "name": 'SpVgg Greuther Furth',
-    #   "logo": 'https://media.api-sports.io/football/teams/178.png',
-    #   "api_id": 178,
-    #   "league_id": 4,
-    #   "home_city": 'Fürth',
-    #   "stadium": 'Sportpark Ronhof Thomas Sommer',
-    #   "last_season_rank": ''
-    # },
     {
-      "id": 76,
+      "id": 182,
       "name": 'Union Berlin',
       "code": 'UNI',
       "logo": 'https://media.api-sports.io/football/teams/182.png',
@@ -1061,21 +1187,46 @@ Team.create(
       "league_id": 4,
       "home_city": 'Berlin',
       "stadium": 'Stadion An der Alten Försterei',
-      "last_season_rank": 4
+      "last_season_rank": 15,
+      "active": true
     },
-    # 2021-2022降格
-    # {
-    #   "id": 77,
-    #   "name": 'Arminia Bielefeld',
-    #   "logo": 'https://media.api-sports.io/football/teams/188.png',
-    #   "api_id": 188,
-    #   "league_id": 4,
-    #   "home_city": 'Bielefeld',
-    #   "stadium": 'SchücoArena',
-    #   "last_season_rank": 15
-    # },
     {
-      "id": 78,
+      "id": 186,
+      "name": 'FC St. Pauli',
+      "code": 'PAU',
+      "logo": 'https://media.api-sports.io/football/teams/186.png',
+      "api_id": 186,
+      "league_id": 4,
+      "home_city": 'Hamburg',
+      "stadium": 'Millerntor-Stadion',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 188,
+      "name": 'Arminia Bielefeld',
+      "logo": 'https://media.api-sports.io/football/teams/188.png',
+      "api_id": 188,
+      "league_id": 4,
+      "home_city": 'Bielefeld',
+      "stadium": 'SchücoArena',
+      "last_season_rank": '',
+      "active": false
+    },
+    {
+      "id": 191,
+      "name": 'Holstein Kiel',
+      "code": 'HOL',
+      "logo": 'https://media.api-sports.io/football/teams/188.png',
+      "api_id": 188,
+      "league_id": 4,
+      "home_city": 'Bielefeld',
+      "stadium": 'SchücoArena',
+      "last_season_rank": '',
+      "active": true
+    },
+    {
+      "id": 192,
       "name": 'FC Koln',
       "code": 'KOL',
       "logo": 'https://media.api-sports.io/football/teams/192.png',
@@ -1083,7 +1234,8 @@ Team.create(
       "league_id": 4,
       "home_city": 'Köln',
       "stadium": 'RheinEnergieStadion',
-      "last_season_rank": 11
+      "last_season_rank": '',
+      "active": false
     }
   ]
 )

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     sequence(:logo) { |n| "https://media.api-sports.io/football/teams/#{n}.png" }
     sequence(:api_id) { |n| n }
     home_city { 'London' }
+    active { true }
+    association :league
 
     trait :arsenal do
       id { 1 }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Team, type: :model do
   end
 
   it 'is invalid with a duplicate logo' do
-    FactoryBot.create(:team, logo: 'https://media.api-sports.io/football/teams/42.png', league)
+    FactoryBot.create(:team, logo: 'https://media.api-sports.io/football/teams/42.png', league:)
     team.valid?
     expect(team.errors[:logo]).to include('はすでに存在します')
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,81 +3,67 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  before do
-    @team = Team.create(
-      id: 1,
-      name: 'Arsenal',
-      logo: 'https://media.api-sports.io/football/teams/42.png',
-      api_id: '42',
-      home_city: 'London',
-      league_id: 1
-    )
+  let(:league) { FactoryBot.create(:league) }
+  let(:team) do
+    FactoryBot.build(:team,
+                     id: 1,
+                     name: 'Arsenal',
+                     logo: 'https://media.api-sports.io/football/teams/42.png',
+                     api_id: '42',
+                     home_city: 'London',
+                     active: true,
+                     league:)
   end
-  it 'is valid with a name, logo, api_id and leaague_id and home_city' do
-    league = FactoryBot.build(:league)
-    team = FactoryBot.build(:team, :arsenal, league:)
+
+  it 'is valid with a name, logo, api_id, league_id, and home_city' do
     expect(team).to be_valid
   end
 
-  it 'is valid without a name' do
-    league = FactoryBot.build(:league)
-    team = FactoryBot.build(:team, name: nil, league:)
+  it 'is invalid without a name' do
+    team.name = nil
     team.valid?
     expect(team.errors[:name]).to include('を入力してください')
   end
 
-  it 'is valid with a duplicate name' do
-    league = FactoryBot.build(:league)
-    FactoryBot.create(:team, :arsenal, league:)
-    team = Team.new(
-      name: 'Arsenal',
-      logo: 'https://media.api-sports.io/football/venues/494.png'
-    )
+  it 'is invalid with a duplicate name' do
+    FactoryBot.create(:team, name: 'Arsenal', league:)
     team.valid?
     expect(team.errors[:name]).to include('はすでに存在します')
   end
 
-  it 'is valid without a logo' do
-    league = FactoryBot.build(:league)
-    team = FactoryBot.build(:team, logo: nil, league:)
+  it 'is invalid without a logo' do
+    team.logo = nil
     team.valid?
     expect(team.errors[:logo]).to include('を入力してください')
   end
 
-  it 'is valid with a duplicate logo' do
-    league = FactoryBot.build(:league)
-    FactoryBot.create(:team, :arsenal, league:)
-    team = Team.new(
-      name: 'Manchester United',
-      logo: 'https://media.api-sports.io/football/teams/42.png'
-    )
+  it 'is invalid with a duplicate logo' do
+    FactoryBot.create(:team, logo: 'https://media.api-sports.io/football/teams/42.png', league)
     team.valid?
     expect(team.errors[:logo]).to include('はすでに存在します')
   end
 
-  it 'is valid without a api_id' do
-    league = FactoryBot.build(:league)
-    team = FactoryBot.build(:team, api_id: nil, league:)
+  it 'is invalid without an api_id' do
+    team.api_id = nil
     team.valid?
     expect(team.errors[:api_id]).to include('を入力してください')
   end
 
-  it 'is valid with a duplicate api_id' do
-    league = FactoryBot.build(:league)
-    FactoryBot.create(:team, :arsenal, league:)
-    team = Team.new(
-      name: 'Manchester United',
-      logo: 'https://media.api-sports.io/football/teams/33.png',
-      api_id: '42'
-    )
+  it 'is invalid with a duplicate api_id' do
+    FactoryBot.create(:team, api_id: '42', league:)
     team.valid?
     expect(team.errors[:api_id]).to include('はすでに存在します')
   end
 
-  it 'is valid without a home_city' do
-    league = FactoryBot.build(:league)
-    team = FactoryBot.build(:team, home_city: nil, league:)
+  it 'is invalid without a home_city' do
+    team.home_city = nil
     team.valid?
     expect(team.errors[:home_city]).to include('を入力してください')
+  end
+
+  it 'is invalid without active status' do
+    team.active = nil
+    team.valid?
+    expect(team.errors[:active]).to include('は一覧にありません')
   end
 end

--- a/spec/requests/api/team_filter_spec.rb
+++ b/spec/requests/api/team_filter_spec.rb
@@ -3,15 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::TeamFilters', type: :request do
+  let!(:league) { FactoryBot.create(:league) }
+  let!(:active_team) { FactoryBot.create(:team, active: true, league:) }
+  let!(:inactive_team) { FactoryBot.create(:team, active: false, league:) }
+  let!(:user_follow_team) { FactoryBot.create(:team, active: true, league:) }
+  let(:user) { FactoryBot.build(:user) }
+
+  before do
+    sign_in user
+    user.favorite_team_follow(user_follow_team)
+  end
+
   describe 'GET /api/team_filter' do
     it 'returns http success' do
-      league = FactoryBot.create(:league)
-      team = FactoryBot.create(:team, league:)
-      user = FactoryBot.build(:user)
-      sign_in user
-      user.favorite_team_follow(team)
       get api_team_filter_index_path(format: :json)
       expect(response).to have_http_status(:success)
+    end
+    it 'returns only active teams' do
+      get '/api/team_filter'
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+      expect(json_response.size).to eq(1)
+      expect(json_response.first['id']).to eq(active_team.id)
     end
   end
 end

--- a/spec/requests/api/teams_spec.rb
+++ b/spec/requests/api/teams_spec.rb
@@ -3,12 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe 'API::teams', type: :request do
+  let!(:league) { FactoryBot.create(:league) }
+  let!(:active_team) { FactoryBot.create(:team, active: true, league:) }
+  let!(:inactive_team) { FactoryBot.create(:team, active: false, league:) }
+
   describe 'GET /api/teams/index' do
     it 'returns http success' do
       user = FactoryBot.build(:user)
       sign_in user
       get api_teams_path(format: :json)
       expect(response).to have_http_status(:success)
+    end
+    it 'returns only active teams' do
+      get '/api/teams'
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+      expect(json_response.size).to eq(1)
+      expect(json_response.first['id']).to eq(active_team.id)
     end
   end
 end


### PR DESCRIPTION
## 対応した issue
#340 

## 対応内容・対応背景・妥協点
- 24-25シーズン用にseed情報を変更する
- Teamテーブルに`active`カラムを追加する
  - 毎年昇格チーム、降格チームを入れ替えるのが大変なため論理値を導入して、論理値を使って管理する
 
## やったこと
- seed情報を入れ替えた
  - 24-25シーズン用にチームを追加した
  - コメントアウトを外した
    - `active`カラムでチームを管理するためコメントアウトは必要なくなった
- Teamテーブルに`active`カラムを追加した
- `MatchRequest`、`StandingRequest`を変更した
  - `uninitialized constant Net::HTTP (NameError)`が発生したため、`require 'net/http'`を追記した。Rails7の影響？

## やってないこと
画面表記に関わること

## UI before / after

特にない

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced an `active` status for teams, enabling better management and filtering options.
	- Updated league and team data to reflect current statuses and performance metrics, enhancing accuracy.

- **Bug Fixes**
	- Removed outdated commented-out code in the seeding process, improving clarity and functionality.
	
- **Documentation**
	- Updated schema to reflect changes in team data structure, ensuring consistency in data handling.

- **Tests**
	- Enhanced test coverage for the `Team` model to align with new validation requirements, including the `active` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->