### PR TITLE
試合結果のホームアンドアウェイが全てHOMEになっている

### DIFF
--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::MatchesController < ApplicationController
-  before_action :set_show_page, only: [:show]
+  before_action :set_team, only: [:show]
 
   def index
     matches = Match.all.order(:date).where(home_team_name: team_names).or(Match.where(away_team_name: team_names))
@@ -9,7 +9,7 @@ class API::MatchesController < ApplicationController
   end
 
   def show
-    @match_show = Match.all.where(team_id: @team_id).order(:date)
+    @match = Match.all.order(:date).where(home_team_name: set_team.name).or(Match.where(away_team_name: set_team.name))
   end
 
   private
@@ -19,8 +19,8 @@ class API::MatchesController < ApplicationController
     teams.map(&:name)
   end
 
-  def set_show_page
-    @team_id = Team.find(params[:id])
+  def set_team
+    Team.find(params[:id])
   end
 
   def selected_team_ids

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -9,7 +9,8 @@ class API::MatchesController < ApplicationController
   end
 
   def show
-    @match = Match.all.order(:date).where(home_team_name: set_team.name).or(Match.where(away_team_name: set_team.name))
+    team = set_team
+    @match = Match.all.order(:date).where(home_team_name: team.name).or(Match.where(away_team_name: team.name))
   end
 
   private

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Match < ApplicationRecord
-  validates :team_id, presence: true
   validates :season, presence: true
   validates :date, presence: true
   validates :competition_name, presence: true
   validates :competition_logo, presence: true
-  validates :team_name, presence: true
-  validates :team_logo, presence: true
   validates :home_and_away, presence: true
+  validates :home_team_name, presence: true
+  validates :away_team_name, presence: true
+  validates :home_logo, presence: true
+  validates :away_logo, presence: true
 end

--- a/app/models/match_request.rb
+++ b/app/models/match_request.rb
@@ -41,10 +41,6 @@ class MatchRequest
     match.away_logo = api['teams']['away']['logo']
     match.home_score = api['goals']['home']
     match.away_score = api['goals']['away']
-    team = Team.find_by(api_id: api['teams']['home']['id'])
-    match.team_id = team.id
-    match.team_name = match.home_team_name
-    match.team_logo = match.home_logo
     match.save
   end
 end

--- a/app/views/api/matches/index.json.jbuilder
+++ b/app/views/api/matches/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :team_id, :season, :date, :competition_name, :competition_logo, :home_and_away, :home_team_name, :home_logo, :home_score, :away_team_name, :away_logo, :away_score, :created_at
+json.array! @match, :season, :date, :competition_name, :competition_logo, :home_and_away, :home_team_name, :home_logo, :home_score, :away_team_name, :away_logo, :away_score, :created_at

--- a/app/views/api/matches/show.json.jbuilder
+++ b/app/views/api/matches/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :season, :date, :competition_name, :competition_logo, :team_logo, :home_and_away, :home_score, :away_score, :home_team_name, :away_team_name, :home_logo, :away_logo
+json.array! @match, :season, :date, :competition_name, :competition_logo, :home_and_away, :home_score, :away_score, :home_team_name, :away_team_name, :home_logo, :away_logo

--- a/app/views/api/matches/show.json.jbuilder
+++ b/app/views/api/matches/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match_show, :team_id, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :home_score, :away_score, :home_team_name, :away_team_name, :home_logo, :away_logo
+json.array! @match, :season, :date, :competition_name, :competition_logo, :team_logo, :home_and_away, :home_score, :away_score, :home_team_name, :away_team_name, :home_logo, :away_logo

--- a/app/views/api/update_matches/index.json.jbuilder
+++ b/app/views/api/update_matches/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :team_id, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away, :created_at
+json.array! @match, :season, :date, :competition_name, :competition_logo, :home_and_away, :created_at

--- a/db/migrate/20240820232234_remove_columns_from_matches.rb
+++ b/db/migrate/20240820232234_remove_columns_from_matches.rb
@@ -1,0 +1,7 @@
+class RemoveColumnsFromMatches < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :matches, :team_id, :integer
+    remove_column :matches, :team_name, :string
+    remove_column :matches, :team_logo, :string
+  end
+end

--- a/db/migrate/20240821002925_change_column_null_in_matches.rb
+++ b/db/migrate/20240821002925_change_column_null_in_matches.rb
@@ -1,0 +1,8 @@
+class ChangeColumnNullInMatches < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :matches, :home_team_name, false
+    change_column_null :matches, :away_team_name, false
+    change_column_null :matches, :home_logo, false
+    change_column_null :matches, :away_logo, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_04_082513) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_21_002925) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,19 +47,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_04_082513) do
     t.date "date", null: false
     t.string "competition_name", null: false
     t.string "competition_logo", null: false
-    t.string "team_name", null: false
-    t.string "team_logo", null: false
     t.string "home_score"
     t.string "away_score"
     t.string "home_and_away", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "home_team_name"
-    t.string "away_team_name"
-    t.string "home_logo"
-    t.string "away_logo"
-    t.bigint "team_id"
-    t.index ["team_id"], name: "index_matches_on_team_id"
+    t.string "home_team_name", null: false
+    t.string "away_team_name", null: false
+    t.string "home_logo", null: false
+    t.string "away_logo", null: false
   end
 
   create_table "standings", force: :cascade do |t|
@@ -110,7 +106,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_04_082513) do
   add_foreign_key "competitors", "users"
   add_foreign_key "favorites", "teams"
   add_foreign_key "favorites", "users"
-  add_foreign_key "matches", "teams"
   add_foreign_key "standings", "teams"
   add_foreign_key "teams", "leagues"
 end

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -4,12 +4,9 @@ FactoryBot.define do
   factory :match do
     id { 1 }
     date { 'Wed, 12 Jan 2022' }
-    team_id { 1 }
     season { 2021 }
     competition_name { 'UEFA Champions League' }
     competition_logo { 'https://media.api-sports.io/football/leagues/2.png' }
-    team_name { 'Villarreal' }
-    team_logo { 'https://media.api-sports.io/football/teams/533.png' }
     home_score { 1 }
     away_score { 1 }
     home_and_away { 'AWAY' }

--- a/spec/javascript/components/Molecules/list/MatchScheduleList.spec.js
+++ b/spec/javascript/components/Molecules/list/MatchScheduleList.spec.js
@@ -1,0 +1,84 @@
+import { mount } from '@vue/test-utils'
+import MatchScheduleCard from 'components/Molecules/list/MatchScheduleList.vue'
+
+describe('MatchScheduleCard.vue', () => {
+  const favoriteTeam = {
+    id: 1,
+    name: "Arsenal",
+    stadium: "Emirates Stadium",
+  }
+
+  const firstOpponentTeam = {
+    id: 2,
+    name: "Wolves",
+    stadium: "Molineux Stadium",
+  }
+
+  const secondOpponentTeam = {
+    id: 3,
+    name: "Aston Villa",
+    stadium: "Villa Park",
+  }
+
+  const matchScheduleFilter = [
+    {
+      id: 1,
+      season: "2024",
+      date: "2024-08-17",
+      home_and_away: "Emirates Stadium",
+      home_team_name: "Arsenal",
+      away_team_name: "Wolves",
+      home_logo: "https://media.api-sports.io/football/teams/42.png",
+      away_logo: "https://media.api-sports.io/football/teams/39.png"
+    },
+    {
+      id: 2,
+      season: "2024",
+      date: "2024-08-24",
+      home_and_away: "Villa Park",
+      home_team_name: "Aston Villa",
+      away_team_name: "Arsenal",
+      home_logo: "https://media.api-sports.io/football/teams/66.png",
+      away_logo: "https://media.api-sports.io/football/teams/42.png",
+    }
+  ]
+
+  it('renders HOME when selectedTeam[0].stadium matches schedule.home_and_away', () => {
+    const selectedTeam = [{ stadium: favoriteTeam.stadium }]
+    const wrapper = mount(MatchScheduleCard, {
+      props: { matchScheduleFilter, selectedTeam }
+    })
+
+    // HOME が表示されていることを確認
+    const homeElement = wrapper.findAll('.home-and-away').at(0)
+    expect(homeElement.exists()).toBe(true)
+    expect(homeElement.text()).toBe('HOME')
+    expect(homeElement.classes()).toContain('has-background-success')
+
+    // AWAY が表示されていることを確認
+    const awayElement = wrapper.findAll('.home-and-away').at(1)
+    expect(awayElement.exists()).toBe(true)
+    expect(awayElement.text()).toBe('AWAY')
+    expect(awayElement.classes()).toContain('has-background-danger')
+  })
+
+  it('renders AWAY when selectedTeam[0].stadium does not match schedule.home_and_away', () => {
+    const selectedTeam = [{ stadium: secondOpponentTeam.stadium }]
+    const wrapper = mount(MatchScheduleCard, {
+      props: { matchScheduleFilter, selectedTeam }
+    })
+
+    // AWAY が表示されていることを確認
+    const awayElement = wrapper.findAll('.home-and-away').at(0)
+    expect(awayElement.exists()).toBe(true)
+    expect(awayElement.text()).toBe('AWAY')
+    expect(awayElement.classes()).toContain('has-background-danger')
+
+    // HOME が表示されていることを確認
+    const homeElement = wrapper.findAll('.home-and-away').at(1)
+    expect(homeElement.exists()).toBe(true)
+    expect(homeElement.text()).toBe('HOME')
+    expect(homeElement.classes()).toContain('has-background-success')
+  })
+})
+

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -15,13 +15,6 @@ RSpec.describe Match, type: :model do
     expect(match.errors[:date]).to include('を入力してください')
   end
 
-  it 'is valid without a team_id' do
-    match = FactoryBot.build(:match, team_id: nil)
-
-    match.valid?
-    expect(match.errors[:team_id]).to include('を入力してください')
-  end
-
   it 'is valid without a season' do
     match = FactoryBot.build(:match, season: nil)
 
@@ -41,20 +34,6 @@ RSpec.describe Match, type: :model do
 
     match.valid?
     expect(match.errors[:competition_logo]).to include('を入力してください')
-  end
-
-  it 'is valid without a team_name' do
-    match = FactoryBot.build(:match, team_name: nil)
-
-    match.valid?
-    expect(match.errors[:team_name]).to include('を入力してください')
-  end
-
-  it 'is valid without a team_logo' do
-    match = FactoryBot.build(:match, team_logo: nil)
-
-    match.valid?
-    expect(match.errors[:team_logo]).to include('を入力してください')
   end
 
   it 'is valid without a home_and_away' do


### PR DESCRIPTION
## 対応した issue
#341 

## 対応内容・対応背景・妥協点
スケジュール詳細に表示される試合情報のホームアンドアウェイがすべてHOMEになっていた。

## やったこと
- API::Matches#showの処理方法を変更した
  - `team_id`を条件にフィルターをかけていたため、ホームの試合しか表示されていなかった
- Matchから使用していないカラムを削除した
  - 今回の対応で`team_id`を使用しなくなったため削除。それに付随して`team_name`、`team_logo`を削除した

## やってないこと

この PR 内でやっていないことを書く

## UI before / after

### before
<img width="889" alt="スクリーンショット 2024-08-10 13 41 26" src="https://github.com/user-attachments/assets/dc741369-f612-4650-9eb6-ee5c8aef5e85">

### after
<img width="912" alt="スクリーンショット 2024-08-21 10 22 09" src="https://github.com/user-attachments/assets/8940984e-371f-4699-8284-b6ef4b6a4365">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced match retrieval by using team names instead of IDs for filtering matches.
	- Improved match data validation to focus on home and away team attributes.

- **Bug Fixes**
	- Removed unnecessary attributes from match responses, improving data clarity.

- **Refactor**
	- Simplified team data handling in match-related processes.

- **Chores**
	- Updated database schema to remove deprecated columns and enforce non-null constraints for essential match details.
	- Cleaned up factory definitions to align with the new match data structure.

- **Tests**
	- Introduced new unit tests for the `MatchScheduleCard` component to validate its rendering behavior. 
	- Modified existing tests to reflect updated validation rules in the `Match` model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->