### PR TITLE
Matchに`fixture_id`を追加する

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Match < ApplicationRecord
+  validates :fixture_id, presence: true
   validates :season, presence: true
   validates :date, presence: true
   validates :competition_name, presence: true

--- a/app/models/match_request.rb
+++ b/app/models/match_request.rb
@@ -30,6 +30,7 @@ class MatchRequest
 
   def data_save(api)
     match = Match.new
+    match.fixture_id = api['fixture']['id']
     match.season = api['league']['season']
     match.date = api['fixture']['date']
     match.home_and_away = api['fixture']['venue']['name']

--- a/app/views/api/matches/index.json.jbuilder
+++ b/app/views/api/matches/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @match, :season, :date, :competition_name, :competition_logo, :home_and_away, :home_team_name, :home_logo, :home_score, :away_team_name, :away_logo, :away_score, :created_at
+json.array! @match, :fixture_id, :season, :date, :competition_name, :competition_logo, :home_and_away, :home_team_name, :home_logo, :home_score, :away_team_name, :away_logo, :away_score, :created_at

--- a/db/migrate/20240917221121_add_fixture_id_to_matches.rb
+++ b/db/migrate/20240917221121_add_fixture_id_to_matches.rb
@@ -1,0 +1,5 @@
+class AddFixtureIdToMatches < ActiveRecord::Migration[7.2]
+  def change
+    add_column :matches, :fixture_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_21_002925) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_17_221121) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_21_002925) do
     t.string "away_team_name", null: false
     t.string "home_logo", null: false
     t.string "away_logo", null: false
+    t.integer "fixture_id"
   end
 
   create_table "standings", force: :cascade do |t|

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :match do
     id { 1 }
+    fixture_id { 1 }
     date { 'Wed, 12 Jan 2022' }
     season { 2021 }
     competition_name { 'UEFA Champions League' }

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe Match, type: :model do
     expect(match).to be_valid
   end
 
+  it 'is valid without a fixture_id' do
+    match = FactoryBot.build(:match, fixture_id: nil)
+
+    match.valid?
+    expect(match.errors[:fixture_id]).to include('を入力してください')
+  end
+
   it 'is valid without a date' do
     match = FactoryBot.build(:match, date: nil)
 


### PR DESCRIPTION
## 対応した issue
#295 #365 

## 対応内容・対応背景・妥協点
`Matches`に`fixtuture_id`のカラムを追加することで試合詳細情報と関連づけられるようにする

## やったこと
- `fixture_id`のカラムを追加
- テスト、バリデーションを追加

## やってないこと
UIが変わるようなこと

## UI before / after
変更なし

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a validation for the presence of `fixture_id` in match records to enhance data integrity.
	- Added `fixture_id` to the API response for matches, providing more context for clients.

- **Bug Fixes**
	- Enhanced the `data_save` method to ensure `fixture_id` is correctly assigned to match objects.

- **Database Changes**
	- Added a new `fixture_id` column to the `matches` table for improved relational mapping.

- **Tests**
	- Added a test case to validate that matches without a `fixture_id` are considered invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->